### PR TITLE
Fix missing configuration resources

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,8 @@
                 <directory>${project.basedir}/src/main/resources</directory>
                 <includes>
                     <include>plugin.yml</include>
+                    <include>config.yml</include>
+                    <include>nexo.yml</include>
                 </includes>
             </resource>
         </resources>


### PR DESCRIPTION
## Summary
- include `config.yml` and `nexo.yml` in the plugin jar so that `saveDefaultConfig()` succeeds

## Testing
- `mvn test` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685228bfe48083309a5fe8aba1c13232