### PR TITLE
Fix missing configuration resources

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,8 @@
                 <directory>${project.basedir}/src/main/resources</directory>
                 <includes>
                     <include>plugin.yml</include>
+                    <include>config.yml</include>
+                    <include>nexo.yml</include>
                 </includes>
             </resource>
         </resources>

--- a/src/main/java/nexo/beta/CommandManager/CommandNexoManager.java
+++ b/src/main/java/nexo/beta/CommandManager/CommandNexoManager.java
@@ -1,0 +1,124 @@
+package nexo.beta.CommandManager;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+import nexo.beta.NexoAndCorruption;
+import nexo.beta.classes.Nexo;
+import nexo.beta.managers.ConfigManager;
+import nexo.beta.managers.NexoManager;
+
+public class CommandNexoManager implements CommandExecutor {
+
+    private final NexoAndCorruption plugin;
+    private final NexoManager nexoManager;
+    private final ConfigManager config;
+
+    public CommandNexoManager(NexoAndCorruption plugin) {
+        this.plugin = plugin;
+        this.nexoManager = plugin.getNexoManager();
+        this.config = plugin.getConfigManager();
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (args.length == 0) {
+            sender.sendMessage("§eUso: /" + label + " <crear|destruir|estado|activar|desactivar|reiniciar|recargar>");
+            return true;
+        }
+
+        String sub = args[0].toLowerCase();
+        switch (sub) {
+            case "crear":
+                if (!(sender instanceof Player player)) {
+                    sender.sendMessage("§cSolo jugadores pueden ejecutar este comando.");
+                    return true;
+                }
+                Location loc = player.getLocation();
+                nexoManager.crearNexo(loc);
+                sender.sendMessage("§aNexo creado en tu ubicación.");
+                break;
+            case "destruir":
+                World world = (sender instanceof Player p) ? p.getWorld() : plugin.getServer().getWorlds().get(0);
+                if (nexoManager.eliminarNexo(world)) {
+                    sender.sendMessage("§cNexo destruido.");
+                } else {
+                    sender.sendMessage(config.getMensajeNexoNoEncontrado());
+                }
+                break;
+            case "estado":
+                if (!config.isComandoEstadoHabilitado()) {
+                    sender.sendMessage("§cComando deshabilitado.");
+                    return true;
+                }
+                Nexo nexoEstado = nexoManager.getNexoEnMundo(sender instanceof Player p ? p.getWorld() : plugin.getServer().getWorlds().get(0));
+                if (nexoEstado == null) {
+                    sender.sendMessage(config.getMensajeNexoNoEncontrado());
+                    return true;
+                }
+                Map<String, Object> phVida = new HashMap<>();
+                phVida.put("vida", nexoEstado.getVida());
+                phVida.put("vida_maxima", config.getVidaMaxima());
+                phVida.put("porcentaje", nexoEstado.getPorcentajeVida());
+                String msgVida = config.replacePlaceholders(config.getMensajeEstadoVida(), phVida);
+                Map<String, Object> phEner = new HashMap<>();
+                phEner.put("energia", nexoEstado.getEnergia());
+                phEner.put("energia_maxima", config.getEnergiaMaxima());
+                phEner.put("porcentaje", nexoEstado.getPorcentajeEnergia());
+                String msgEner = config.replacePlaceholders(config.getMensajeEstadoEnergia(), phEner);
+                sender.sendMessage(config.getPrefijo() + msgVida);
+                sender.sendMessage(config.getPrefijo() + msgEner);
+                break;
+            case "activar":
+                Nexo nexoAct = nexoManager.getNexoEnMundo(sender instanceof Player p ? p.getWorld() : plugin.getServer().getWorlds().get(0));
+                if (nexoAct == null) {
+                    sender.sendMessage(config.getMensajeNexoNoEncontrado());
+                    return true;
+                }
+                nexoAct.activar();
+                sender.sendMessage("§aNexo activado.");
+                break;
+            case "desactivar":
+                Nexo nexoDes = nexoManager.getNexoEnMundo(sender instanceof Player p ? p.getWorld() : plugin.getServer().getWorlds().get(0));
+                if (nexoDes == null) {
+                    sender.sendMessage(config.getMensajeNexoNoEncontrado());
+                    return true;
+                }
+                nexoDes.desactivar();
+                sender.sendMessage("§cNexo desactivado.");
+                break;
+            case "reiniciar":
+                if (!config.isComandoReiniciarHabilitado()) {
+                    sender.sendMessage("§cComando deshabilitado.");
+                    return true;
+                }
+                Nexo nexoRei = nexoManager.getNexoEnMundo(sender instanceof Player p ? p.getWorld() : plugin.getServer().getWorlds().get(0));
+                if (nexoRei == null) {
+                    sender.sendMessage(config.getMensajeNexoNoEncontrado());
+                    return true;
+                }
+                nexoRei.reiniciar();
+                sender.sendMessage("§aNexo reiniciado.");
+                break;
+            case "recargar":
+                if (!config.isComandoRecargarHabilitado()) {
+                    sender.sendMessage("§cComando deshabilitado.");
+                    return true;
+                }
+                plugin.reloadPlugin();
+                sender.sendMessage("§aPlugin recargado.");
+                break;
+            default:
+                sender.sendMessage("§eUso: /" + label + " <crear|destruir|estado|activar|desactivar|reiniciar|recargar>");
+                break;
+        }
+        return true;
+    }
+}

--- a/src/main/java/nexo/beta/NexoAndCorruption.java
+++ b/src/main/java/nexo/beta/NexoAndCorruption.java
@@ -6,6 +6,7 @@ import nexo.beta.listeners.PlayerListener;
 import nexo.beta.managers.ConfigManager;
 import nexo.beta.managers.NexoManager;
 import nexo.beta.managers.PluginManager;
+import nexo.beta.CommandManager.CommandNexoManager;
 
 public class NexoAndCorruption extends JavaPlugin {
     
@@ -74,8 +75,7 @@ public class NexoAndCorruption extends JavaPlugin {
      * Registra los comandos del plugin
      */
     private void registerCommands() {
-        // Aquí registrarás tus comandos cuando los crees
-        // getCommand("nexo").setExecutor(new NexoCommand(this));
+        getCommand("nexo").setExecutor(new CommandNexoManager(this));
         getLogger().info("§a✅ Comandos registrados");
     }
     

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -3,3 +3,8 @@ version: 1.0.0-SNAPSHOT
 name: NexoAndCorruption
 author: Lubodi
 api-version: 1.20
+commands:
+  nexo:
+    description: Gestiona el Nexo protector
+    usage: /<command> <crear|destruir|estado|activar|desactivar|reiniciar|recargar>
+    permission: nexo.admin


### PR DESCRIPTION
## Summary
- include `config.yml` and `nexo.yml` in the plugin jar so that `saveDefaultConfig()` succeeds
- add `CommandNexoManager` for plugin commands

## Testing
- `mvn test` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685228bfe48083309a5fe8aba1c13232