### PR TITLE
Implement invasion event

### DIFF
--- a/src/main/java/nexo/beta/CommandManager/CommandNexoManager.java
+++ b/src/main/java/nexo/beta/CommandManager/CommandNexoManager.java
@@ -30,7 +30,7 @@ public class CommandNexoManager implements CommandExecutor {
     @Override
     public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
         if (args.length == 0) {
-            sender.sendMessage("§eUso: /" + label + " <crear|destruir|estado|activar|desactivar|reiniciar|recargar|expandir>");
+            sender.sendMessage("§eUso: /" + label + " <crear|destruir|estado|activar|desactivar|reiniciar|recargar|expandir|invasion>");
             return true;
         }
 
@@ -127,6 +127,10 @@ public class CommandNexoManager implements CommandExecutor {
                 nexoExp.expandirRadio(cant);
                 sender.sendMessage("§aNuevo radio: " + nexoExp.getRadioActual());
                 break;
+            case "invasion":
+                plugin.getPluginManager().getInvasionManager().forzarInvasion();
+                sender.sendMessage("§aInvasión forzada.");
+                break;
             case "recargar":
                 if (!config.isComandoRecargarHabilitado()) {
                     sender.sendMessage("§cComando deshabilitado.");
@@ -136,7 +140,7 @@ public class CommandNexoManager implements CommandExecutor {
                 sender.sendMessage("§aPlugin recargado.");
                 break;
             default:
-                sender.sendMessage("§eUso: /" + label + " <crear|destruir|estado|activar|desactivar|reiniciar|recargar|expandir>");
+                sender.sendMessage("§eUso: /" + label + " <crear|destruir|estado|activar|desactivar|reiniciar|recargar|expandir|invasion>");
                 break;
         }
         return true;

--- a/src/main/java/nexo/beta/Events/InvasionManager.java
+++ b/src/main/java/nexo/beta/Events/InvasionManager.java
@@ -1,0 +1,157 @@
+package nexo.beta.Events;
+
+import java.util.Map;
+import java.util.Random;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.Monster;
+import org.bukkit.scheduler.BukkitRunnable;
+import org.bukkit.scheduler.BukkitTask;
+
+import nexo.beta.NexoAndCorruption;
+import nexo.beta.classes.Nexo;
+import nexo.beta.managers.ConfigManager;
+import nexo.beta.managers.NexoManager;
+import nexo.beta.utils.Utils;
+
+public class InvasionManager {
+
+    private final NexoAndCorruption plugin;
+    private final NexoManager nexoManager;
+    private ConfigManager config;
+
+    private BukkitTask checkTask;
+    private BukkitTask spawnTask;
+    private boolean invasionActiva = false;
+
+    public InvasionManager(NexoAndCorruption plugin, NexoManager nexoManager, ConfigManager config) {
+        this.plugin = plugin;
+        this.nexoManager = nexoManager;
+        this.config = config;
+    }
+
+    public void start() {
+        long intervalo = 20L * 60; // cada minuto
+        checkTask = new BukkitRunnable() {
+            @Override
+            public void run() {
+                verificarInvasion();
+            }
+        }.runTaskTimer(plugin, intervalo, intervalo);
+    }
+
+    public void shutdown() {
+        if (checkTask != null) {
+            checkTask.cancel();
+        }
+        if (spawnTask != null) {
+            spawnTask.cancel();
+        }
+        invasionActiva = false;
+    }
+
+    public void reload(ConfigManager newConfig) {
+        shutdown();
+        this.config = newConfig;
+        start();
+    }
+
+    public void forzarInvasion() {
+        if (!invasionActiva) {
+            iniciarCuentaRegresiva();
+        }
+    }
+
+    private void verificarInvasion() {
+        if (invasionActiva) return;
+        double prob = config.getInvasionProbabilidad();
+        if (Math.random() <= prob) {
+            iniciarCuentaRegresiva();
+        }
+    }
+
+    private void iniciarCuentaRegresiva() {
+        Bukkit.broadcastMessage(Utils.colorize(config.getMensajePrevioEvento()));
+        new BukkitRunnable() {
+            int tiempo = config.getInvasionAdvertencia();
+            @Override
+            public void run() {
+                if (tiempo <= 0) {
+                    iniciarInvasion();
+                    cancel();
+                    return;
+                }
+                if (tiempo % 10 == 0 || tiempo <= 5) {
+                    Bukkit.broadcastMessage(Utils.colorize(config.getPrefijo() + "§cInvasión en " + tiempo + "s"));
+                }
+                tiempo--;
+            }
+        }.runTaskTimer(plugin, 0L, 20L);
+    }
+
+    private void iniciarInvasion() {
+        invasionActiva = true;
+        Bukkit.broadcastMessage(Utils.colorize(config.getMensajeInicioEvento()));
+        spawnTask = new BukkitRunnable() {
+            int tiempo = config.getInvasionDuracion();
+            @Override
+            public void run() {
+                if (tiempo <= 0) {
+                    finalizarInvasion();
+                    cancel();
+                    return;
+                }
+                generarEntidades();
+                tiempo--;
+            }
+        }.runTaskTimer(plugin, 0L, 20L);
+    }
+
+    private void finalizarInvasion() {
+        invasionActiva = false;
+        Bukkit.broadcastMessage(Utils.colorize(config.getMensajeFinEvento()));
+    }
+
+    private void generarEntidades() {
+        Map<String, Double> mobs = config.getInvasionMobs();
+        if (mobs.isEmpty()) return;
+        Random rnd = new Random();
+        for (Nexo nexo : nexoManager.getTodosLosNexos().values()) {
+            Location centro = nexo.getUbicacion();
+            World world = centro.getWorld();
+            if (world == null) continue;
+
+            double angulo = rnd.nextDouble() * 2 * Math.PI;
+            double distancia = rnd.nextDouble() * config.getInvasionRadioSpawn();
+            double x = centro.getX() + Math.cos(angulo) * distancia;
+            double z = centro.getZ() + Math.sin(angulo) * distancia;
+            double y = world.getHighestBlockYAt((int) x, (int) z) + 1;
+            Location loc = new Location(world, x, y, z);
+
+            EntityType tipo = elegirTipo(mobs, rnd.nextDouble());
+            Entity entidad = world.spawnEntity(loc, tipo);
+            if (entidad instanceof Monster monster) {
+                monster.setTarget(nexo.getWarden());
+            }
+        }
+    }
+
+    private EntityType elegirTipo(Map<String, Double> mapa, double random) {
+        double acumulado = 0;
+        for (Map.Entry<String, Double> entry : mapa.entrySet()) {
+            acumulado += entry.getValue();
+            if (random <= acumulado) {
+                try {
+                    return EntityType.valueOf(entry.getKey());
+                } catch (IllegalArgumentException e) {
+                    // ignore invalid
+                }
+            }
+        }
+        return EntityType.ZOMBIE;
+    }
+}

--- a/src/main/java/nexo/beta/managers/ConfigManager.java
+++ b/src/main/java/nexo/beta/managers/ConfigManager.java
@@ -142,6 +142,36 @@ public class ConfigManager {
     public List<Map<?, ?>> getEfectosEventoEspecial() {
         return nexoConfig.getMapList("nexo.eventos_especiales.efectos");
     }
+
+    // ==========================================
+    // MÉTODOS PARA INVASIONES
+    // ==========================================
+
+    public double getInvasionProbabilidad() {
+        return nexoConfig.getDouble("nexo.invasion.probabilidad", 0.1);
+    }
+
+    public int getInvasionAdvertencia() {
+        return nexoConfig.getInt("nexo.invasion.advertencia", 30);
+    }
+
+    public int getInvasionDuracion() {
+        return nexoConfig.getInt("nexo.invasion.duracion", 30);
+    }
+
+    public int getInvasionRadioSpawn() {
+        return nexoConfig.getInt("nexo.invasion.radio_spawn", 100);
+    }
+
+    public Map<String, Double> getInvasionMobs() {
+        Map<String, Double> result = new java.util.HashMap<>();
+        if (nexoConfig.isConfigurationSection("nexo.invasion.mobs")) {
+            for (String key : nexoConfig.getConfigurationSection("nexo.invasion.mobs").getKeys(false)) {
+                result.put(key.toUpperCase(), nexoConfig.getDouble("nexo.invasion.mobs." + key));
+            }
+        }
+        return result;
+    }
     
     // ==========================================
     // MÉTODOS PARA PROTECCIONES

--- a/src/main/java/nexo/beta/managers/PluginManager.java
+++ b/src/main/java/nexo/beta/managers/PluginManager.java
@@ -6,6 +6,7 @@ public class PluginManager {
     private static PluginManager instance;
     private ConfigManager configManager;
     private NexoManager nexoManager;
+    private nexo.beta.Events.InvasionManager invasionManager;
     private NexoAndCorruption plugin;
     
     public static PluginManager getInstance() {
@@ -27,6 +28,8 @@ public class PluginManager {
             
             // 2. Inicializar NexoManager
             initializeNexoManager();
+
+            initializeInvasionManager();
             
             plugin.getLogger().info("§a✅ Todos los managers inicializados correctamente");
             
@@ -53,6 +56,12 @@ public class PluginManager {
         nexoManager = NexoManager.getInstance();
         plugin.getLogger().info("§a✅ NexoManager inicializado");
     }
+
+    private void initializeInvasionManager() {
+        invasionManager = new nexo.beta.Events.InvasionManager(plugin, nexoManager, configManager);
+        invasionManager.start();
+        plugin.getLogger().info("§a✅ InvasionManager inicializado");
+    }
     
     /**
      * Detiene todos los managers
@@ -63,6 +72,10 @@ public class PluginManager {
         // Detener NexoManager
         if (nexoManager != null) {
             nexoManager.shutdown();
+        }
+
+        if (invasionManager != null) {
+            invasionManager.shutdown();
         }
         
         plugin.getLogger().info("§a✅ Todos los managers detenidos correctamente");
@@ -84,6 +97,10 @@ public class PluginManager {
             if (nexoManager != null) {
                 nexoManager.recargarConfiguracion();
             }
+
+            if (invasionManager != null) {
+                invasionManager.reload(configManager);
+            }
             
             plugin.getLogger().info("§a✅ Todos los managers recargados correctamente");
             
@@ -103,6 +120,10 @@ public class PluginManager {
     
     public NexoManager getNexoManager() {
         return nexoManager;
+    }
+
+    public nexo.beta.Events.InvasionManager getInvasionManager() {
+        return invasionManager;
     }
     
     public NexoAndCorruption getPlugin() {

--- a/src/main/resources/nexo.yml
+++ b/src/main/resources/nexo.yml
@@ -72,6 +72,18 @@ nexo:
         amplificador: 0
         area_radio: 75
 
+  # Configuración de invasiones aleatorias
+  invasion:
+    probabilidad: 1.0          # Probabilidad de que ocurra la invasión
+    advertencia: 30            # Segundos de aviso antes de iniciar
+    duracion: 30               # Duración de la invasión en segundos
+    radio_spawn: 100           # Radio máximo para spawnear criaturas
+    mobs:
+      ZOMBIE: 0.4
+      SKELETON: 0.3
+      CREEPER: 0.2
+      WARDEN: 0.1
+
   # Sistema de protecciones
   protecciones:
     # Protección contra explosiones


### PR DESCRIPTION
## Summary
- add random invasion event manager
- allow forcing invasion via `/nexo invasion`
- integrate `InvasionManager` with PluginManager
- extend configuration with invasion options

## Testing
- `mvn -q -DskipTests package` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_68531d9669e08330a070120fbc2c4574