### PR TITLE
Spawn mobs outside of protection radius

### DIFF
--- a/src/main/java/nexo/beta/Events/InvasionManager.java
+++ b/src/main/java/nexo/beta/Events/InvasionManager.java
@@ -177,7 +177,9 @@ public class InvasionManager {
             if (world == null) continue;
 
             double angulo = rnd.nextDouble() * 2 * Math.PI;
-            double distancia = rnd.nextDouble() * config.getInvasionRadioSpawn();
+            int maxDist = config.getInvasionRadioSpawn();
+            int minDist = config.getRadioProteccion();
+            double distancia = minDist + rnd.nextDouble() * (maxDist - minDist);
             double x = centro.getX() + Math.cos(angulo) * distancia;
             double z = centro.getZ() + Math.sin(angulo) * distancia;
             double y = world.getHighestBlockYAt((int) x, (int) z) + 1;


### PR DESCRIPTION
## Summary
- spawn invading entities outside the Nexo protection radius

## Testing
- `mvn -q -DskipTests package` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_685390b30b2c83308b82b9df9959463f