### PR TITLE
Cleanup nexo.yml and trailing spaces

### DIFF
--- a/src/main/java/nexo/beta/NexoAndCorruption.java
+++ b/src/main/java/nexo/beta/NexoAndCorruption.java
@@ -10,60 +10,60 @@ import nexo.beta.managers.PluginManager;
 import nexo.beta.CommandManager.CommandNexoManager;
 
 public class NexoAndCorruption extends JavaPlugin {
-    
+
     private static NexoAndCorruption instance;
     private PluginManager pluginManager;
-    
+
     @Override
     public void onEnable() {
         // Establecer instancia
         instance = this;
-        
+
         getLogger().info("§6⚡ Iniciando NexoAndCorruption...");
-        
+
         try {
             // Initialize managers
             pluginManager = PluginManager.getInstance();
             pluginManager.initialize(this);
-            
+
             // Register listeners
             registerListeners();
-            
+
             // Register commands (si los tienes)
             registerCommands();
-            
+
             getLogger().info("§a✅ NexoAndCorruption has been enabled!");
-            
+
             // Mostrar información de debug si está habilitado
             if (getConfigManager().isDebugHabilitado()) {
                 showDebugInfo();
             }
-            
+
         } catch (Exception e) {
             getLogger().severe("§c❌ Error crítico durante la inicialización: " + e.getMessage());
             e.printStackTrace();
             getServer().getPluginManager().disablePlugin(this);
         }
     }
-    
+
     @Override
     public void onDisable() {
         getLogger().info("§6⚡ Deteniendo NexoAndCorruption...");
-        
+
         try {
             // Shutdown managers
             if (pluginManager != null) {
                 pluginManager.shutdown();
             }
-            
+
             getLogger().info("§a✅ NexoAndCorruption has been disabled!");
-            
+
         } catch (Exception e) {
             getLogger().severe("§c❌ Error durante el apagado: " + e.getMessage());
             e.printStackTrace();
         }
     }
-    
+
     /**
      * Registra los listeners del plugin
      */
@@ -72,7 +72,7 @@ public class NexoAndCorruption extends JavaPlugin {
         getServer().getPluginManager().registerEvents(new ProtectionListener(), this);
         getLogger().info("§a✅ Listeners registrados");
     }
-    
+
     /**
      * Registra los comandos del plugin
      */
@@ -80,14 +80,14 @@ public class NexoAndCorruption extends JavaPlugin {
         getCommand("nexo").setExecutor(new CommandNexoManager(this));
         getLogger().info("§a✅ Comandos registrados");
     }
-    
+
     /**
      * Muestra información de debug al iniciar
      */
     private void showDebugInfo() {
         ConfigManager config = getConfigManager();
         NexoManager nexo = getNexoManager();
-        
+
         getLogger().info("§e[DEBUG] ==========================================");
         getLogger().info("§e[DEBUG] INFORMACIÓN DE DEBUG DEL NEXO");
         getLogger().info("§e[DEBUG] ==========================================");
@@ -102,13 +102,13 @@ public class NexoAndCorruption extends JavaPlugin {
         getLogger().info("§e[DEBUG] Eventos especiales: " + config.isEventosEspecialesHabilitado());
         getLogger().info("§e[DEBUG] ==========================================");
     }
-    
+
     /**
      * Recarga todo el plugin
      */
     public void reloadPlugin() {
         getLogger().info("§6⟳ Recargando NexoAndCorruption...");
-        
+
         try {
             if (pluginManager != null) {
                 pluginManager.reload();
@@ -119,50 +119,50 @@ public class NexoAndCorruption extends JavaPlugin {
             e.printStackTrace();
         }
     }
-    
+
     // ==========================================
     // MÉTODOS ESTÁTICOS DE ACCESO
     // ==========================================
-    
+
     /**
      * Obtiene la instancia del plugin
      */
     public static NexoAndCorruption getInstance() {
         return instance;
     }
-    
+
     /**
      * Obtiene el ConfigManager
      */
     public ConfigManager getConfigManager() {
         return pluginManager != null ? pluginManager.getConfigManager() : null;
     }
-    
+
     /**
      * Obtiene el NexoManager
      */
     public NexoManager getNexoManager() {
         return pluginManager != null ? pluginManager.getNexoManager() : null;
     }
-    
+
     /**
      * Obtiene el PluginManager
      */
     public PluginManager getPluginManager() {
         return pluginManager;
     }
-    
+
     // ==========================================
     // MÉTODOS DE UTILIDAD ESTÁTICOS
     // ==========================================
-    
+
     /**
      * Método estático para obtener el ConfigManager
      */
     public static ConfigManager getConfigManagerStatic() {
         return getInstance().getConfigManager();
     }
-    
+
     /**
      * Método estático para obtener el NexoManager
      */

--- a/src/main/java/nexo/beta/classes/Nexo.java
+++ b/src/main/java/nexo/beta/classes/Nexo.java
@@ -32,13 +32,13 @@ import nexo.beta.utils.BarrierUtils;
 import nexo.beta.utils.Utils;
 
 public class Nexo {
-    
+
     private final Location ubicacion;
     private ConfigManager configManager;
     private final Logger logger;
     private final String barrierId;
     private static final String WARDEN_TAG = "nexo_warden";
-    
+
     // Estados del Nexo
     private int vida;
     private int energia;
@@ -51,7 +51,7 @@ public class Nexo {
     // Radio de protección
     private int radioBase;
     private int radioActual;
-    
+
     // Sistema de partículas y efectos
     private BukkitTask taskParticulas;
     private BukkitTask taskEfectos;
@@ -60,15 +60,15 @@ public class Nexo {
     // Representación física del Nexo
     private Warden warden;
     private ArmorStand texturaStand;
-    
+
     // Control de mensajes críticos
     private long ultimoMensajeVidaBaja = 0;
     private long ultimoMensajeEnergiaBaja = 0;
-    
+
     // Archivo de guardado individual
     private File archivoGuardado;
     private FileConfiguration datosNexo;
-    
+
     /**
      * Constructor del Nexo
      */
@@ -77,7 +77,7 @@ public class Nexo {
         this.configManager = configManager;
         this.logger = Bukkit.getLogger();
         this.barrierId = "nexo_" + this.ubicacion.getWorld().getUID();
-        
+
         // Inicializar estados
         this.vida = configManager.getVidaMaxima();
         this.energia = configManager.getEnergiaMaxima();
@@ -85,10 +85,10 @@ public class Nexo {
         this.enEstadoCritico = false;
         this.radioBase = configManager.getRadioProteccion();
         this.radioActual = this.radioBase;
-        
+
         // Inicializar archivo de guardado
         inicializarArchivoGuardado();
-        
+
         // Cargar datos existentes
         cargarDatos();
 
@@ -102,32 +102,32 @@ public class Nexo {
         actualizarBarrera();
 
         iniciarEliminacionMobs();
-        
+
         if (configManager.isDebugHabilitado()) {
-            logger.info("§e[DEBUG] Nexo creado en: " + 
+            logger.info("§e[DEBUG] Nexo creado en: " +
                        ubicacion.getWorld().getName() + " " +
-                       ubicacion.getBlockX() + ", " + 
-                       ubicacion.getBlockY() + ", " + 
+                       ubicacion.getBlockX() + ", " +
+                       ubicacion.getBlockY() + ", " +
                        ubicacion.getBlockZ());
         }
     }
-    
+
     /**
      * Inicializa el archivo de guardado del Nexo
      */
     private void inicializarArchivoGuardado() {
-        String nombreArchivo = "nexo_" + ubicacion.getWorld().getName() + "_" + 
-                              ubicacion.getBlockX() + "_" + 
-                              ubicacion.getBlockY() + "_" + 
+        String nombreArchivo = "nexo_" + ubicacion.getWorld().getName() + "_" +
+                              ubicacion.getBlockX() + "_" +
+                              ubicacion.getBlockY() + "_" +
                               ubicacion.getBlockZ() + ".yml";
-        
-        archivoGuardado = new File(Bukkit.getPluginManager().getPlugin("NexoAndCorruption").getDataFolder(), 
+
+        archivoGuardado = new File(Bukkit.getPluginManager().getPlugin("NexoAndCorruption").getDataFolder(),
                                   "nexos/" + nombreArchivo);
-        
+
         if (!archivoGuardado.getParentFile().exists()) {
             archivoGuardado.getParentFile().mkdirs();
         }
-        
+
         if (!archivoGuardado.exists()) {
             try {
                 archivoGuardado.createNewFile();
@@ -135,10 +135,10 @@ public class Nexo {
                 logger.severe("§c❌ Error al crear archivo de guardado del Nexo: " + e.getMessage());
             }
         }
-        
+
         datosNexo = YamlConfiguration.loadConfiguration(archivoGuardado);
     }
-    
+
     /**
      * Carga los datos guardados del Nexo
      */
@@ -146,11 +146,11 @@ public class Nexo {
         if (datosNexo.contains("vida")) {
             this.vida = datosNexo.getInt("vida", configManager.getVidaMaxima());
         }
-        
+
         if (datosNexo.contains("energia")) {
             this.energia = datosNexo.getInt("energia", configManager.getEnergiaMaxima());
         }
-        
+
         if (datosNexo.contains("activo")) {
             this.activo = datosNexo.getBoolean("activo", true);
         }
@@ -162,17 +162,17 @@ public class Nexo {
         }
 
         this.radioBase = configManager.getRadioProteccion();
-        
+
         // Validar que los valores no excedan los máximos
         this.vida = Math.min(this.vida, configManager.getVidaMaxima());
         this.energia = Math.min(this.energia, configManager.getEnergiaMaxima());
-        
+
         if (configManager.isDebugHabilitado()) {
-            logger.info("§e[DEBUG] Datos del Nexo cargados - Vida: " + vida + 
+            logger.info("§e[DEBUG] Datos del Nexo cargados - Vida: " + vida +
                        ", Energía: " + energia + ", Activo: " + activo);
         }
     }
-    
+
     /**
      * Guarda los datos del Nexo
      */
@@ -183,19 +183,19 @@ public class Nexo {
             datosNexo.set("activo", activo);
             datosNexo.set("radio", radioActual);
             datosNexo.set("ultima_actualizacion", System.currentTimeMillis());
-            
+
             // Guardar ubicación
             datosNexo.set("ubicacion.mundo", ubicacion.getWorld().getName());
             datosNexo.set("ubicacion.x", ubicacion.getX());
             datosNexo.set("ubicacion.y", ubicacion.getY());
             datosNexo.set("ubicacion.z", ubicacion.getZ());
-            
+
             datosNexo.save(archivoGuardado);
-            
+
             if (configManager.isDebugHabilitado()) {
                 logger.info("§e[DEBUG] Datos del Nexo guardados correctamente");
             }
-            
+
         } catch (IOException e) {
             logger.severe("§c❌ Error al guardar datos del Nexo: " + e.getMessage());
         }
@@ -240,13 +240,13 @@ public class Nexo {
             warden.remove();
         }
     }
-    
+
     /**
      * Inicia los efectos visuales del Nexo
      */
     private void iniciarEfectosVisuales() {
         if (!configManager.isParticulasHabilitadas()) return;
-        
+
         // Task para partículas
         taskParticulas = new BukkitRunnable() {
             @Override
@@ -255,57 +255,57 @@ public class Nexo {
                     mostrarParticulas();
                 }
             }
-        }.runTaskTimer(Bukkit.getPluginManager().getPlugin("NexoAndCorruption"), 
+        }.runTaskTimer(Bukkit.getPluginManager().getPlugin("NexoAndCorruption"),
                       0L, configManager.getIntervaloParticulas() * 20L);
-        
+
         // Task para efectos de estado crítico
         taskEfectos = new BukkitRunnable() {
             @Override
             public void run() {
                 verificarEstadosCriticos();
             }
-        }.runTaskTimer(Bukkit.getPluginManager().getPlugin("NexoAndCorruption"), 
+        }.runTaskTimer(Bukkit.getPluginManager().getPlugin("NexoAndCorruption"),
                       20L, 20L); // Cada segundo
     }
-    
+
     /**
      * Muestra partículas del Nexo
      */
     private void mostrarParticulas() {
         if (ubicacion.getWorld() == null) return;
-        
+
         try {
             Particle particula = Particle.valueOf(configManager.getTipoParticula());
-            
+
             // Crear un efecto circular alrededor del Nexo
             for (int i = 0; i < configManager.getCantidadParticulas(); i++) {
                 double angulo = 2 * Math.PI * i / configManager.getCantidadParticulas();
                 double x = ubicacion.getX() + Math.cos(angulo) * 2;
                 double z = ubicacion.getZ() + Math.sin(angulo) * 2;
                 double y = ubicacion.getY() + 0.5;
-                
+
                 Location particleLocation = new Location(ubicacion.getWorld(), x, y, z);
                 ubicacion.getWorld().spawnParticle(particula, particleLocation, 1, 0, 0, 0, 0);
             }
-            
+
             // Partículas adicionales si está en estado crítico
             if (enEstadoCritico) {
-                ubicacion.getWorld().spawnParticle(Particle.SMOKE_NORMAL, 
-                                                 ubicacion.clone().add(0, 1, 0), 
+                ubicacion.getWorld().spawnParticle(Particle.SMOKE_NORMAL,
+                                                 ubicacion.clone().add(0, 1, 0),
                                                  5, 0.5, 0.5, 0.5, 0.01);
             }
-            
+
         } catch (IllegalArgumentException e) {
             logger.warning("§c⚠️ Tipo de partícula inválido: " + configManager.getTipoParticula());
         }
     }
-    
+
     /**
      * Verifica los estados críticos del Nexo
      */
     private void verificarEstadosCriticos() {
         long tiempoActual = System.currentTimeMillis();
-        
+
         // Verificar vida baja
         if (estaVidaBaja()) {
             if (tiempoActual - ultimoMensajeVidaBaja >= configManager.getIntervaloMensajeVidaBaja() * 1000L) {
@@ -313,7 +313,7 @@ public class Nexo {
                 ultimoMensajeVidaBaja = tiempoActual;
             }
         }
-        
+
         // Verificar energía baja
         if (estaEnergiaBaja()) {
             if (tiempoActual - ultimoMensajeEnergiaBaja >= configManager.getIntervaloMensajeEnergiaBaja() * 1000L) {
@@ -321,7 +321,7 @@ public class Nexo {
                 ultimoMensajeEnergiaBaja = tiempoActual;
             }
         }
-        
+
         boolean nuevoEstado = estaVidaBaja() || estaEnergiaBaja();
         if (nuevoEstado != enEstadoCritico) {
             enEstadoCritico = nuevoEstado;
@@ -330,7 +330,7 @@ public class Nexo {
             enEstadoCritico = nuevoEstado;
         }
     }
-    
+
     /**
      * Envía mensaje de vida baja
      */
@@ -339,14 +339,14 @@ public class Nexo {
         placeholders.put("vida", vida);
         placeholders.put("vida_maxima", configManager.getVidaMaxima());
         placeholders.put("porcentaje", getPorcentajeVida());
-        
+
         String mensaje = configManager.replacePlaceholders(
-            configManager.getPrefijo() + configManager.getMensajeVidaBaja(), 
+            configManager.getPrefijo() + configManager.getMensajeVidaBaja(),
             placeholders
         );
-        
+
         Bukkit.broadcastMessage(mensaje);
-        
+
         // Reproducir sonido
         if (configManager.isSonidosHabilitados()) {
             for (Player player : Bukkit.getOnlinePlayers()) {
@@ -356,7 +356,7 @@ public class Nexo {
             }
         }
     }
-    
+
     /**
      * Envía mensaje de energía baja
      */
@@ -365,14 +365,14 @@ public class Nexo {
         placeholders.put("energia", energia);
         placeholders.put("energia_maxima", configManager.getEnergiaMaxima());
         placeholders.put("porcentaje", getPorcentajeEnergia());
-        
+
         String mensaje = configManager.replacePlaceholders(
-            configManager.getPrefijo() + configManager.getMensajeEnergiaBaja(), 
+            configManager.getPrefijo() + configManager.getMensajeEnergiaBaja(),
             placeholders
         );
-        
+
         Bukkit.broadcastMessage(mensaje);
-        
+
         // Reproducir sonido
         if (configManager.isSonidosHabilitados()) {
             for (Player player : Bukkit.getOnlinePlayers()) {
@@ -382,13 +382,13 @@ public class Nexo {
             }
         }
     }
-    
+
     /**
      * Verifica si hay jugadores cerca del Nexo
      */
     public boolean hayJugadoresCerca(int radio, int minimoJugadores) {
         if (ubicacion.getWorld() == null) return false;
-        
+
         int jugadoresCerca = 0;
         for (Player player : ubicacion.getWorld().getPlayers()) {
             if (player.getLocation().distance(ubicacion) <= radio) {
@@ -398,21 +398,21 @@ public class Nexo {
                 }
             }
         }
-        
+
         return false;
     }
-    
+
     /**
      * Desactiva el Nexo
      */
     public void desactivar() {
         if (!activo) return;
-        
+
         activo = false;
-        
+
         // Enviar mensaje de desactivación
         Bukkit.broadcastMessage(configManager.getPrefijo() + configManager.getMensajeNexoDesactivado());
-        
+
         // Reproducir sonido de desactivación
         if (configManager.isSonidosHabilitados()) {
             for (Player player : Bukkit.getOnlinePlayers()) {
@@ -421,7 +421,7 @@ public class Nexo {
                 }
             }
         }
-        
+
         // Guardar estado
         guardar();
 
@@ -431,18 +431,18 @@ public class Nexo {
 
         logger.info("§c❌ Nexo desactivado en " + ubicacion.getWorld().getName());
     }
-    
+
     /**
      * Activa el Nexo
      */
     public void activar() {
         if (activo) return;
-        
+
         activo = true;
-        
+
         // Enviar mensaje de activación
         Bukkit.broadcastMessage(configManager.getPrefijo() + configManager.getMensajeNexoActivado());
-        
+
         // Reproducir sonido de activación
         if (configManager.isSonidosHabilitados()) {
             for (Player player : Bukkit.getOnlinePlayers()) {
@@ -451,7 +451,7 @@ public class Nexo {
                 }
             }
         }
-        
+
         // Guardar estado
         guardar();
 
@@ -461,7 +461,7 @@ public class Nexo {
 
         logger.info("§a✅ Nexo activado en " + ubicacion.getWorld().getName());
     }
-    
+
     /**
      * Inicia un proceso de reinicio del Nexo. Durante el reinicio el Nexo se
      * mantiene desactivado y al finalizar recupera todos sus valores.
@@ -557,7 +557,7 @@ public class Nexo {
         int max = 1200; // 20 minutos
         return (int) Math.round(max - (max - min) * porcentaje);
     }
-    
+
     /**
      * Destruye el Nexo y limpia sus recursos
      */
@@ -566,7 +566,7 @@ public class Nexo {
         if (taskParticulas != null && !taskParticulas.isCancelled()) {
             taskParticulas.cancel();
         }
-        
+
         if (taskEfectos != null && !taskEfectos.isCancelled()) {
             taskEfectos.cancel();
         }
@@ -575,7 +575,7 @@ public class Nexo {
             taskReinicio.cancel();
         }
         reiniciando = false;
-        
+
         // Guardar antes de destruir
         guardar();
 
@@ -590,7 +590,7 @@ public class Nexo {
 
         logger.info("§c❌ Nexo destruido en " + ubicacion.getWorld().getName());
     }
-    
+
     /**
      * Recarga la configuración del Nexo
      */
@@ -601,12 +601,12 @@ public class Nexo {
         if (radioActual < radioBase) {
             radioActual = radioBase;
         }
-        
+
         // Reiniciar efectos visuales con nueva configuración
         if (taskParticulas != null && !taskParticulas.isCancelled()) {
             taskParticulas.cancel();
         }
-        
+
         if (taskEfectos != null && !taskEfectos.isCancelled()) {
             taskEfectos.cancel();
         }
@@ -618,44 +618,44 @@ public class Nexo {
             iniciarEliminacionMobs();
         }
         actualizarBarrera();
-        
+
         logger.info("§a✅ Configuración del Nexo recargada");
     }
-    
+
     // ==========================================
     // MÉTODOS DE VERIFICACIÓN DE ESTADO
     // ==========================================
-    
+
     public boolean estaVidaBaja() {
         int porcentaje = (vida * 100) / configManager.getVidaMaxima();
         return porcentaje <= configManager.getPorcentajeVidaBaja();
     }
-    
+
     public boolean estaEnergiaBaja() {
         int porcentaje = (energia * 100) / configManager.getEnergiaMaxima();
         return porcentaje <= configManager.getPorcentajeEnergiaBaja();
     }
-    
+
     public int getPorcentajeVida() {
         return (vida * 100) / configManager.getVidaMaxima();
     }
-    
+
     public int getPorcentajeEnergia() {
         return (energia * 100) / configManager.getEnergiaMaxima();
     }
-    
+
     // ==========================================
     // GETTERS Y SETTERS
     // ==========================================
-    
+
     public Location getUbicacion() {
         return ubicacion.clone();
     }
-    
+
     public int getVida() {
         return vida;
     }
-    
+
     public void setVida(int vida) {
         this.vida = Math.max(0, Math.min(vida, configManager.getVidaMaxima()));
 
@@ -670,11 +670,11 @@ public class Nexo {
             destroyRepresentation();
         }
     }
-    
+
     public int getEnergia() {
         return energia;
     }
-    
+
     public void setEnergia(int energia) {
         this.energia = Math.max(0, Math.min(energia, configManager.getEnergiaMaxima()));
     }
@@ -682,11 +682,11 @@ public class Nexo {
     public void alimentar(int cantidad) {
         setEnergia(this.energia + cantidad);
     }
-    
+
     public boolean estaActivo() {
         return activo;
     }
-    
+
     public boolean estaEnEstadoCritico() {
         return enEstadoCritico;
     }
@@ -702,7 +702,7 @@ public class Nexo {
     public Warden getWarden() {
         return warden;
     }
-    
+
     public ConfigManager getConfigManager() {
         return configManager;
     }

--- a/src/main/java/nexo/beta/listeners/PlayerListener.java
+++ b/src/main/java/nexo/beta/listeners/PlayerListener.java
@@ -15,7 +15,7 @@ import nexo.beta.classes.Nexo;
 import nexo.beta.managers.NexoManager;
 
 public class PlayerListener implements Listener {
-    
+
     @EventHandler
     public void onPlayerJoin(PlayerJoinEvent event) {
         // Handle player join event

--- a/src/main/java/nexo/beta/managers/ConfigManager.java
+++ b/src/main/java/nexo/beta/managers/ConfigManager.java
@@ -12,23 +12,23 @@ import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.plugin.java.JavaPlugin;
 
 public class ConfigManager {
-    
+
 
     private final JavaPlugin plugin;
     private FileConfiguration config;
     private FileConfiguration nexoConfig;
     private File nexoFile;
-    
+
     public ConfigManager(JavaPlugin plugin) {
         this.plugin = plugin;
         initializeConfigs();
     }
-    
+
     private void initializeConfigs() {
         // Cargar config.yml por defecto
         plugin.saveDefaultConfig();
         config = plugin.getConfig();
-        
+
         // Cargar nexo.yml
         nexoFile = new File(plugin.getDataFolder(), "nexo.yml");
         if (!nexoFile.exists()) {
@@ -36,7 +36,7 @@ public class ConfigManager {
         }
         nexoConfig = YamlConfiguration.loadConfiguration(nexoFile);
     }
-    
+
     /**
      * Recarga todas las configuraciones
      */
@@ -45,100 +45,100 @@ public class ConfigManager {
         config = plugin.getConfig();
         nexoConfig = YamlConfiguration.loadConfiguration(nexoFile);
     }
-    
+
     // ==========================================
     // MÉTODOS PARA CONFIGURACIÓN BÁSICA DEL NEXO
     // ==========================================
-    
+
     public int getVidaMaxima() {
         return nexoConfig.getInt("nexo.vida_maxima", 1000);
     }
-    
+
     public int getEnergiaMaxima() {
         return nexoConfig.getInt("nexo.energia_maxima", 1000);
     }
-    
+
     public int getConsumoEnergiaPorMinuto() {
         return nexoConfig.getInt("nexo.energia_consumo_por_minuto", 10);
     }
-    
+
     public int getRadioProteccion() {
         return nexoConfig.getInt("nexo.radio_proteccion", 50);
     }
-    
+
     // ==========================================
     // MÉTODOS PARA UBICACIÓN DEL NEXO
     // ==========================================
-    
+
     public Location getUbicacionNexo() {
         String mundo = nexoConfig.getString("nexo.ubicacion.mundo", "world");
         double x = nexoConfig.getDouble("nexo.ubicacion.x", 0);
         double y = nexoConfig.getDouble("nexo.ubicacion.y", 100);
         double z = nexoConfig.getDouble("nexo.ubicacion.z", 0);
-        
+
         World world = Bukkit.getWorld(mundo);
         if (world == null) {
             world = Bukkit.getWorlds().get(0); // Usar el primer mundo disponible
         }
-        
+
         return new Location(world, x, y, z);
     }
-    
+
     // ==========================================
     // MÉTODOS PARA SISTEMA DE REINICIO
     // ==========================================
-    
+
     public boolean isReinicioHabilitado() {
         return nexoConfig.getBoolean("nexo.reinicio.habilitado", true);
     }
-    
+
     public boolean isReinicioAleatorio() {
         return nexoConfig.getBoolean("nexo.reinicio.aleatorio", true);
     }
-    
+
     public int getIntervaloReinicioMin() {
         return nexoConfig.getInt("nexo.reinicio.intervalo_min", 3600);
     }
-    
+
     public int getIntervaloReinicioMax() {
         return nexoConfig.getInt("nexo.reinicio.intervalo_max", 10800);
     }
-    
+
     public List<Map<?, ?>> getAdvertenciasReinicio() {
         return nexoConfig.getMapList("nexo.reinicio.advertencias");
     }
-    
+
     // ==========================================
     // MÉTODOS PARA EVENTOS ESPECIALES
     // ==========================================
-    
+
     public boolean isEventosEspecialesHabilitado() {
         return nexoConfig.getBoolean("nexo.eventos_especiales.habilitado", true);
     }
-    
+
     public double getProbabilidadEventoEspecial() {
         return nexoConfig.getDouble("nexo.eventos_especiales.probabilidad", 0.25);
     }
-    
+
     public String getMensajePrevioEvento() {
-        return nexoConfig.getString("nexo.eventos_especiales.mensaje_previo", 
+        return nexoConfig.getString("nexo.eventos_especiales.mensaje_previo",
             "‼️ El Nexo siente una gran perturbación en la energía...");
     }
-    
+
     public String getMensajeInicioEvento() {
-        return nexoConfig.getString("nexo.eventos_especiales.mensaje_inicio", 
+        return nexoConfig.getString("nexo.eventos_especiales.mensaje_inicio",
             "🔥 ¡INVASIÓN ESPECIAL ACTIVADA! Las defensas del Nexo han fallado.");
     }
-    
+
     public String getMensajeFinEvento() {
-        return nexoConfig.getString("nexo.eventos_especiales.mensaje_fin", 
+        return nexoConfig.getString("nexo.eventos_especiales.mensaje_fin",
             "✅ El Nexo ha recuperado su estabilidad. La invasión ha terminado.");
     }
-    
+
     public int getDuracionEventoEspecial() {
         return nexoConfig.getInt("nexo.eventos_especiales.duracion", 1200);
     }
-    
+
     public List<Map<?, ?>> getEfectosEventoEspecial() {
         return nexoConfig.getMapList("nexo.eventos_especiales.efectos");
     }
@@ -172,45 +172,45 @@ public class ConfigManager {
         }
         return result;
     }
-    
+
     // ==========================================
     // MÉTODOS PARA PROTECCIONES
     // ==========================================
-    
+
     public boolean isProteccionExplosionesHabilitada() {
         return nexoConfig.getBoolean("nexo.protecciones.explosiones.habilitado", true);
     }
-    
+
     public boolean isBloquearExplosiones() {
         return nexoConfig.getBoolean("nexo.protecciones.explosiones.bloquear", true);
     }
-    
+
     public String getMensajeProteccionExplosiones() {
-        return nexoConfig.getString("nexo.protecciones.explosiones.mensaje", 
+        return nexoConfig.getString("nexo.protecciones.explosiones.mensaje",
             "🛡️ El Nexo protege esta área de explosiones.");
     }
-    
+
     public boolean isProteccionPvPHabilitada() {
         return nexoConfig.getBoolean("nexo.protecciones.pvp.habilitado", true);
     }
-    
+
     public boolean isBloquearPvP() {
         return nexoConfig.getBoolean("nexo.protecciones.pvp.bloquear", true);
     }
-    
+
     public String getMensajeProteccionPvP() {
-        return nexoConfig.getString("nexo.protecciones.pvp.mensaje", 
+        return nexoConfig.getString("nexo.protecciones.pvp.mensaje",
             "⚔️ El Nexo no permite combate en esta zona protegida.");
     }
-    
+
     public boolean isProteccionBloquesHabilitada() {
         return nexoConfig.getBoolean("nexo.protecciones.bloques.habilitado", true);
     }
-    
+
     public boolean isPermitirConstruccion() {
         return nexoConfig.getBoolean("nexo.protecciones.bloques.permitir_construccion", false);
     }
-    
+
     public boolean isPermitirDestruccion() {
         return nexoConfig.getBoolean("nexo.protecciones.bloques.permitir_destruccion", false);
     }
@@ -218,12 +218,12 @@ public class ConfigManager {
     public int getRadioRestriccionBloques() {
         return nexoConfig.getInt("nexo.protecciones.bloques.radio_restriccion", 30);
     }
-    
+
     public String getMensajeProteccionBloques() {
-        return nexoConfig.getString("nexo.protecciones.bloques.mensaje", 
+        return nexoConfig.getString("nexo.protecciones.bloques.mensaje",
             "🏗️ El Nexo protege los bloques de esta área.");
     }
-    
+
     public boolean isProteccionContenedoresHabilitada() {
         return nexoConfig.getBoolean("nexo.protecciones.contenedores.habilitado", true);
     }
@@ -231,64 +231,64 @@ public class ConfigManager {
     public int getRadioRestriccionContenedores() {
         return nexoConfig.getInt("nexo.protecciones.contenedores.radio_restriccion", getRadioRestriccionBloques());
     }
-    
+
     public String getMensajeProteccionContenedores() {
-        return nexoConfig.getString("nexo.protecciones.contenedores.mensaje", 
+        return nexoConfig.getString("nexo.protecciones.contenedores.mensaje",
             "📦 Los contenedores están protegidos por el Nexo.");
     }
-    
+
     // ==========================================
     // MÉTODOS PARA REGENERACIÓN
     // ==========================================
-    
+
     public boolean isRegeneracionHabilitada() {
         return nexoConfig.getBoolean("nexo.regeneracion.habilitado", true);
     }
-    
+
     public int getEnergiaPorSegundo() {
         return nexoConfig.getInt("nexo.regeneracion.energia_por_segundo", 2);
     }
-    
+
     public int getVidaPorSegundo() {
         return nexoConfig.getInt("nexo.regeneracion.vida_por_segundo", 1);
     }
-    
+
     public boolean isRequiereJugadoresCerca() {
         return nexoConfig.getBoolean("nexo.regeneracion.requiere_jugadores_cerca", false);
     }
-    
+
     public int getRadioMinimoJugadores() {
         return nexoConfig.getInt("nexo.regeneracion.radio_minimo_jugadores", 20);
     }
-    
+
     public int getMinimoJugadores() {
         return nexoConfig.getInt("nexo.regeneracion.minimo_jugadores", 1);
     }
-    
+
     // ==========================================
     // MÉTODOS PARA EFECTOS VISUALES
     // ==========================================
-    
+
     public boolean isParticulasHabilitadas() {
         return nexoConfig.getBoolean("nexo.efectos.particulas.habilitado", true);
     }
-    
+
     public String getTipoParticula() {
         return nexoConfig.getString("nexo.efectos.particulas.tipo", "ENCHANTMENT_TABLE");
     }
-    
+
     public int getCantidadParticulas() {
         return nexoConfig.getInt("nexo.efectos.particulas.cantidad", 10);
     }
-    
+
     public int getIntervaloParticulas() {
         return nexoConfig.getInt("nexo.efectos.particulas.intervalo", 5);
     }
-    
+
     public boolean isSonidosHabilitados() {
         return nexoConfig.getBoolean("nexo.efectos.sonidos.habilitado", true);
     }
-    
+
     public Sound getSonidoEnergiaBaja() {
         String soundName = nexoConfig.getString("nexo.efectos.sonidos.energia_baja", "BLOCK_NOTE_BLOCK_BASS");
         try {
@@ -297,7 +297,7 @@ public class ConfigManager {
             return Sound.BLOCK_NOTE_BLOCK_BASS;
         }
     }
-    
+
     public Sound getSonidoVidaBaja() {
         String soundName = nexoConfig.getString("nexo.efectos.sonidos.vida_baja", "ENTITY_VILLAGER_HURT");
         try {
@@ -306,7 +306,7 @@ public class ConfigManager {
             return Sound.ENTITY_VILLAGER_HURT;
         }
     }
-    
+
     public Sound getSonidoReinicio() {
         String soundName = nexoConfig.getString("nexo.efectos.sonidos.reinicio", "BLOCK_END_PORTAL_SPAWN");
         try {
@@ -315,148 +315,148 @@ public class ConfigManager {
             return Sound.BLOCK_END_PORTAL_SPAWN;
         }
     }
-    
+
     // ==========================================
     // MÉTODOS PARA ESTADOS CRÍTICOS
     // ==========================================
-    
+
     public int getPorcentajeVidaBaja() {
         return nexoConfig.getInt("nexo.estados_criticos.vida_baja.porcentaje", 25);
     }
-    
+
     public String getMensajeVidaBaja() {
-        return nexoConfig.getString("nexo.estados_criticos.vida_baja.mensaje", 
+        return nexoConfig.getString("nexo.estados_criticos.vida_baja.mensaje",
             "🆘 ¡ALERTA! El Nexo está gravemente dañado ({vida}/{vida_maxima})");
     }
-    
+
     public int getIntervaloMensajeVidaBaja() {
         return nexoConfig.getInt("nexo.estados_criticos.vida_baja.intervalo_mensaje", 30);
     }
-    
+
     public int getPorcentajeEnergiaBaja() {
         return nexoConfig.getInt("nexo.estados_criticos.energia_baja.porcentaje", 20);
     }
-    
+
     public String getMensajeEnergiaBaja() {
-        return nexoConfig.getString("nexo.estados_criticos.energia_baja.mensaje", 
+        return nexoConfig.getString("nexo.estados_criticos.energia_baja.mensaje",
             "⚡ El Nexo tiene poca energía ({energia}/{energia_maxima}). Las protecciones se debilitan.");
     }
-    
+
     public int getIntervaloMensajeEnergiaBaja() {
         return nexoConfig.getInt("nexo.estados_criticos.energia_baja.intervalo_mensaje", 45);
     }
-    
+
     public String getMensajeNexoInactivo() {
-        return nexoConfig.getString("nexo.estados_criticos.nexo_inactivo.mensaje", 
+        return nexoConfig.getString("nexo.estados_criticos.nexo_inactivo.mensaje",
             "💀 ¡EL NEXO HA CAÍDO! Las protecciones han desaparecido.");
     }
-    
+
     // ==========================================
     // MÉTODOS PARA COMANDOS
     // ==========================================
-    
+
     public boolean isComandoEstadoHabilitado() {
         return nexoConfig.getBoolean("nexo.comandos.estado.habilitado", true);
     }
-    
+
     public String getPermisoComandoEstado() {
         return nexoConfig.getString("nexo.comandos.estado.permiso", "nexo.estado");
     }
-    
+
     public boolean isComandoRecargarHabilitado() {
         return nexoConfig.getBoolean("nexo.comandos.recargar.habilitado", true);
     }
-    
+
     public String getPermisoComandoRecargar() {
         return nexoConfig.getString("nexo.comandos.recargar.permiso", "nexo.admin.recargar");
     }
-    
+
     public boolean isComandoReiniciarHabilitado() {
         return nexoConfig.getBoolean("nexo.comandos.reiniciar.habilitado", true);
     }
-    
+
     public String getPermisoComandoReiniciar() {
         return nexoConfig.getString("nexo.comandos.reiniciar.permiso", "nexo.admin.reiniciar");
     }
-    
+
     // ==========================================
     // MÉTODOS PARA GUARDADO
     // ==========================================
-    
+
     public int getIntervaloGuardadoAuto() {
         return nexoConfig.getInt("nexo.guardado.intervalo_auto", 300);
     }
-    
+
     public boolean isGuardarAlApagar() {
         return nexoConfig.getBoolean("nexo.guardado.guardar_al_apagar", true);
     }
-    
+
     public String getArchivoGuardado() {
         return nexoConfig.getString("nexo.guardado.archivo", "nexo_data.yml");
     }
-    
+
     // ==========================================
     // MÉTODOS PARA MENSAJES
     // ==========================================
-    
+
     public String getPrefijo() {
         return nexoConfig.getString("nexo.mensajes.prefijo", "§8[§6Nexo§8] §r");
     }
-    
+
     public String getMensajeNexoActivado() {
-        return getPrefijo() + nexoConfig.getString("nexo.mensajes.nexo_activado", 
+        return getPrefijo() + nexoConfig.getString("nexo.mensajes.nexo_activado",
             "§a✅ El Nexo ha sido activado y está protegiendo el área.");
     }
-    
+
     public String getMensajeNexoDesactivado() {
-        return getPrefijo() + nexoConfig.getString("nexo.mensajes.nexo_desactivado", 
+        return getPrefijo() + nexoConfig.getString("nexo.mensajes.nexo_desactivado",
             "§c❌ El Nexo ha sido desactivado. ¡Cuidado!");
     }
-    
+
     public String getMensajeEstadoVida() {
-        return nexoConfig.getString("nexo.mensajes.estado_vida", 
+        return nexoConfig.getString("nexo.mensajes.estado_vida",
             "§6Vida del Nexo: §e{vida}§6/§e{vida_maxima} §6({porcentaje}%)");
     }
-    
+
     public String getMensajeEstadoEnergia() {
-        return nexoConfig.getString("nexo.mensajes.estado_energia", 
+        return nexoConfig.getString("nexo.mensajes.estado_energia",
             "§b⚡ Energía: §e{energia}§b/§e{energia_maxima} §b({porcentaje}%)");
     }
-    
+
     public String getMensajeNexoNoEncontrado() {
-        return getPrefijo() + nexoConfig.getString("nexo.mensajes.nexo_no_encontrado", 
+        return getPrefijo() + nexoConfig.getString("nexo.mensajes.nexo_no_encontrado",
             "§cError: No se pudo encontrar el Nexo.");
     }
-    
+
     public String getMensajeSinPermisos() {
-        return getPrefijo() + nexoConfig.getString("nexo.mensajes.sin_permisos", 
+        return getPrefijo() + nexoConfig.getString("nexo.mensajes.sin_permisos",
             "§cNo tienes permisos para usar este comando.");
     }
-    
+
     // ==========================================
     // MÉTODOS PARA DEBUG
     // ==========================================
-    
+
     public boolean isDebugHabilitado() {
         return nexoConfig.getBoolean("debug.habilitado", false);
     }
-    
+
     public boolean isMostrarCoordenadas() {
         return nexoConfig.getBoolean("debug.mostrar_coordenadas", true);
     }
-    
+
     public boolean isMostrarCalculosEnergia() {
         return nexoConfig.getBoolean("debug.mostrar_calculos_energia", false);
     }
-    
+
     public boolean isMostrarEventos() {
         return nexoConfig.getBoolean("debug.mostrar_eventos", true);
     }
-    
+
     // ==========================================
     // MÉTODOS AUXILIARES
     // ==========================================
-    
+
     /**
      * Reemplaza placeholders en mensajes
      */
@@ -467,14 +467,14 @@ public class ConfigManager {
         }
         return result;
     }
-    
+
     /**
      * Obtiene el archivo de configuración del nexo
      */
     public FileConfiguration getNexoConfig() {
         return nexoConfig;
     }
-    
+
     /**
      * Obtiene el archivo de configuración principal
      */

--- a/src/main/java/nexo/beta/managers/NexoManager.java
+++ b/src/main/java/nexo/beta/managers/NexoManager.java
@@ -15,27 +15,27 @@ import nexo.beta.classes.Nexo;
 import nexo.beta.managers.PluginManager;
 
 public class NexoManager {
-    
+
     private static NexoManager instance;
     private final NexoAndCorruption plugin;
     private final ConfigManager configManager;
     private final Logger logger;
-    
+
     // Mapa para almacenar un Nexo por mundo (UUID del mundo -> Nexo)
     private final Map<UUID, Nexo> nexosPorMundo;
-    
+
     // Tasks para el sistema de regeneración y consumo
     private BukkitTask taskRegeneracion;
     private BukkitTask taskConsumoEnergia;
     private BukkitTask taskGuardadoAutomatico;
-    
+
     private NexoManager(NexoAndCorruption plugin, ConfigManager configManager) {
         this.plugin = plugin;
         this.configManager = configManager;
         this.logger = plugin.getLogger();
         this.nexosPorMundo = new HashMap<>();
     }
-    
+
     /**
      * Inicializa el NexoManager (llamado desde PluginManager)
      */
@@ -45,29 +45,29 @@ public class NexoManager {
             instance.startSystems();
         }
     }
-    
+
     /**
      * Obtiene la instancia del NexoManager
      */
     public static NexoManager getInstance() {
         return instance;
     }
-    
+
     /**
      * Inicia todos los sistemas del Nexo
      */
     private void startSystems() {
         logger.info("§6⚡ Iniciando sistemas del Nexo...");
-        
+
         // Cargar Nexos existentes
         loadExistingNexos();
-        
+
         // Iniciar tareas automáticas
         startAutomaticTasks();
-        
+
         logger.info("§a✅ Sistemas del Nexo iniciados correctamente");
     }
-    
+
     /**
      * Carga los Nexos existentes desde la configuración
      */
@@ -75,14 +75,14 @@ public class NexoManager {
         try {
             Location ubicacion = configManager.getUbicacionNexo();
             World mundo = ubicacion.getWorld();
-            
+
             if (mundo != null) {
                 // Crear o cargar el Nexo para este mundo
                 Nexo nexo = new Nexo(ubicacion, configManager);
                 nexosPorMundo.put(mundo.getUID(), nexo);
-                
+
                 if (configManager.isDebugHabilitado()) {
-                    logger.info("§e[DEBUG] Nexo cargado en mundo: " + mundo.getName() + 
+                    logger.info("§e[DEBUG] Nexo cargado en mundo: " + mundo.getName() +
                                " en " + ubicacion.getBlockX() + ", " + ubicacion.getBlockY() + ", " + ubicacion.getBlockZ());
                 }
             } else {
@@ -93,7 +93,7 @@ public class NexoManager {
             e.printStackTrace();
         }
     }
-    
+
     /**
      * Inicia las tareas automáticas del sistema
      */
@@ -107,7 +107,7 @@ public class NexoManager {
                 }
             }.runTaskTimer(plugin, 20L, 20L); // Cada segundo (20 ticks)
         }
-        
+
         // Task de consumo de energía (cada minuto)
         taskConsumoEnergia = new BukkitRunnable() {
             @Override
@@ -115,7 +115,7 @@ public class NexoManager {
                 consumirEnergiaTodosLosNexos();
             }
         }.runTaskTimer(plugin, 1200L, 1200L); // Cada minuto (1200 ticks)
-        
+
         // Task de guardado automático
         if (configManager.getIntervaloGuardadoAuto() > 0) {
             long intervalo = configManager.getIntervaloGuardadoAuto() * 20L; // Convertir segundos a ticks
@@ -126,16 +126,16 @@ public class NexoManager {
                 }
             }.runTaskTimer(plugin, intervalo, intervalo);
         }
-        
+
         logger.info("§a✅ Tareas automáticas del Nexo iniciadas");
     }
-    
+
     /**
      * Detiene todos los sistemas del Nexo
      */
     public void shutdown() {
         logger.info("§6⚡ Deteniendo sistemas del Nexo...");
-        
+
         // Cancelar tareas
         if (taskRegeneracion != null && !taskRegeneracion.isCancelled()) {
             taskRegeneracion.cancel();
@@ -146,50 +146,50 @@ public class NexoManager {
         if (taskGuardadoAutomatico != null && !taskGuardadoAutomatico.isCancelled()) {
             taskGuardadoAutomatico.cancel();
         }
-        
+
         // Guardar todos los Nexos antes de cerrar
         if (configManager.isGuardarAlApagar()) {
             guardarTodosLosNexos();
         }
-        
+
         // Limpiar mapa
         nexosPorMundo.clear();
-        
+
         logger.info("§a✅ Sistemas del Nexo detenidos correctamente");
     }
-    
+
     // ==========================================
     // MÉTODOS DE GESTIÓN DE NEXOS
     // ==========================================
-    
+
     /**
      * Obtiene el Nexo de un mundo específico
      */
     public Nexo getNexoEnMundo(World mundo) {
         return nexosPorMundo.get(mundo.getUID());
     }
-    
+
     /**
      * Obtiene el Nexo más cercano a una ubicación
      */
     public Nexo getNexoCercano(Location ubicacion) {
         World mundo = ubicacion.getWorld();
         if (mundo == null) return null;
-        
+
         return getNexoEnMundo(mundo);
     }
-    
+
     /**
      * Verifica si una ubicación está dentro del radio de protección de algún Nexo
      */
     public boolean estaEnZonaProtegida(Location ubicacion) {
         Nexo nexo = getNexoCercano(ubicacion);
         if (nexo == null || !nexo.estaActivo()) return false;
-        
+
         double distancia = nexo.getUbicacion().distance(ubicacion);
         return distancia <= configManager.getRadioProteccion();
     }
-    
+
     /**
      * Crea un nuevo Nexo en la ubicación especificada
      */
@@ -199,23 +199,23 @@ public class NexoManager {
             logger.warning("§c⚠️ No se puede crear un Nexo en un mundo nulo");
             return null;
         }
-        
+
         // Verificar si ya existe un Nexo en este mundo
         if (nexosPorMundo.containsKey(mundo.getUID())) {
             logger.warning("§c⚠️ Ya existe un Nexo en el mundo: " + mundo.getName());
             return nexosPorMundo.get(mundo.getUID());
         }
-        
+
         // Crear nuevo Nexo
         Nexo nuevoNexo = new Nexo(ubicacion, configManager);
         nexosPorMundo.put(mundo.getUID(), nuevoNexo);
-        
-        logger.info("§a✅ Nuevo Nexo creado en " + mundo.getName() + 
+
+        logger.info("§a✅ Nuevo Nexo creado en " + mundo.getName() +
                    " (" + ubicacion.getBlockX() + ", " + ubicacion.getBlockY() + ", " + ubicacion.getBlockZ() + ")");
-        
+
         return nuevoNexo;
     }
-    
+
     /**
      * Elimina el Nexo de un mundo
      */
@@ -229,11 +229,11 @@ public class NexoManager {
         }
         return false;
     }
-    
+
     // ==========================================
     // MÉTODOS DE REGENERACIÓN Y CONSUMO
     // ==========================================
-    
+
     /**
      * Regenera la vida y energía de todos los Nexos activos
      */
@@ -242,30 +242,30 @@ public class NexoManager {
             if (nexo.estaActivo()) {
                 // Verificar si requiere jugadores cerca
                 if (configManager.isRequiereJugadoresCerca()) {
-                    if (!nexo.hayJugadoresCerca(configManager.getRadioMinimoJugadores(), 
+                    if (!nexo.hayJugadoresCerca(configManager.getRadioMinimoJugadores(),
                                                configManager.getMinimoJugadores())) {
                         continue; // Saltar regeneración si no hay jugadores cerca
                     }
                 }
-                
+
                 // Regenerar vida
                 int vidaActual = nexo.getVida();
                 int vidaMaxima = configManager.getVidaMaxima();
                 int regeneracionVida = configManager.getVidaPorSegundo();
-                
+
                 if (vidaActual < vidaMaxima && nexo.getEnergia() > 0) {
                     nexo.setVida(Math.min(vidaMaxima, vidaActual + regeneracionVida));
                 }
             }
         }
     }
-    
+
     /**
      * Consume energía de todos los Nexos activos
      */
     private void consumirEnergiaTodosLosNexos() {
         int consumoBase = configManager.getConsumoEnergiaPorMinuto();
-        
+
         for (Nexo nexo : nexosPorMundo.values()) {
             if (nexo.estaActivo()) {
                 double factor = (double) nexo.getRadioActual() / configManager.getRadioProteccion();
@@ -274,14 +274,14 @@ public class NexoManager {
                 int energiaActual = nexo.getEnergia();
                 int nuevaEnergia = Math.max(0, energiaActual - consumo);
                 nexo.setEnergia(nuevaEnergia);
-                
+
                 // Si se queda sin energía, desactivar el Nexo
                 if (nuevaEnergia <= 0) {
                     nexo.desactivar();
-                    logger.warning("§c⚠️ Nexo en " + nexo.getUbicacion().getWorld().getName() + 
+                    logger.warning("§c⚠️ Nexo en " + nexo.getUbicacion().getWorld().getName() +
                                   " se ha desactivado por falta de energía");
                 }
-                
+
                 if (configManager.isDebugHabilitado() && configManager.isMostrarCalculosEnergia()) {
                     logger.info("§e[DEBUG] Nexo consumió " + consumo + " energía. " +
                                "Energía actual: " + nuevaEnergia + "/" + configManager.getEnergiaMaxima());
@@ -289,11 +289,11 @@ public class NexoManager {
             }
         }
     }
-    
+
     // ==========================================
     // MÉTODOS DE GUARDADO Y CARGA
     // ==========================================
-    
+
     /**
      * Guarda todos los Nexos
      */
@@ -301,18 +301,18 @@ public class NexoManager {
         for (Nexo nexo : nexosPorMundo.values()) {
             nexo.guardar();
         }
-        
+
         if (configManager.isDebugHabilitado()) {
             logger.info("§e[DEBUG] Guardado automático de Nexos completado");
         }
     }
-    
+
     /**
      * Recarga la configuración y reinicia los sistemas si es necesario
      */
     public void recargarConfiguracion() {
         logger.info("§6⟳ Recargando configuración del NexoManager...");
-        
+
         // Detener tareas actuales
         if (taskRegeneracion != null && !taskRegeneracion.isCancelled()) {
             taskRegeneracion.cancel();
@@ -323,29 +323,29 @@ public class NexoManager {
         if (taskGuardadoAutomatico != null && !taskGuardadoAutomatico.isCancelled()) {
             taskGuardadoAutomatico.cancel();
         }
-        
+
         // Recargar configuración de todos los Nexos
         for (Nexo nexo : nexosPorMundo.values()) {
             nexo.recargarConfiguracion(configManager);
         }
-        
+
         // Reiniciar tareas automáticas
         startAutomaticTasks();
-        
+
         logger.info("§a✅ Configuración del NexoManager recargada");
     }
-    
+
     // ==========================================
     // MÉTODOS DE INFORMACIÓN Y ESTADÍSTICAS
     // ==========================================
-    
+
     /**
      * Obtiene información de todos los Nexos
      */
     public Map<UUID, Nexo> getTodosLosNexos() {
         return new HashMap<>(nexosPorMundo);
     }
-    
+
     /**
      * Obtiene el número total de Nexos activos
      */
@@ -354,22 +354,22 @@ public class NexoManager {
                 .filter(Nexo::estaActivo)
                 .count();
     }
-    
+
     /**
      * Obtiene el número total de Nexos
      */
     public int getTotalNexos() {
         return nexosPorMundo.size();
     }
-    
+
     // ==========================================
     // GETTERS
     // ==========================================
-    
+
     public ConfigManager getConfigManager() {
         return configManager;
     }
-    
+
     public NexoAndCorruption getPlugin() {
         return plugin;
     }

--- a/src/main/java/nexo/beta/managers/PluginManager.java
+++ b/src/main/java/nexo/beta/managers/PluginManager.java
@@ -8,38 +8,38 @@ public class PluginManager {
     private NexoManager nexoManager;
     private nexo.beta.Events.InvasionManager invasionManager;
     private NexoAndCorruption plugin;
-    
+
     public static PluginManager getInstance() {
         if (instance == null) {
             instance = new PluginManager();
         }
         return instance;
     }
-    
+
     /**
      * Inicializa todos los managers del plugin
      */
     public void initialize(NexoAndCorruption plugin) {
         this.plugin = plugin;
-        
+
         try {
             // 1. Inicializar ConfigManager primero
             initializeConfigManager();
-            
+
             // 2. Inicializar NexoManager
             initializeNexoManager();
 
             initializeInvasionManager();
-            
+
             plugin.getLogger().info("§a✅ Todos los managers inicializados correctamente");
-            
+
         } catch (Exception e) {
             plugin.getLogger().severe("§c❌ Error crítico al inicializar managers: " + e.getMessage());
             e.printStackTrace();
             plugin.getServer().getPluginManager().disablePlugin(plugin);
         }
     }
-    
+
     /**
      * Inicializa el ConfigManager
      */
@@ -47,7 +47,7 @@ public class PluginManager {
         configManager = new ConfigManager(plugin);
         plugin.getLogger().info("§a✅ ConfigManager inicializado");
     }
-    
+
     /**
      * Inicializa el NexoManager
      */
@@ -62,13 +62,13 @@ public class PluginManager {
         invasionManager.start();
         plugin.getLogger().info("§a✅ InvasionManager inicializado");
     }
-    
+
     /**
      * Detiene todos los managers
      */
     public void shutdown() {
         plugin.getLogger().info("§6⚡ Deteniendo todos los managers...");
-        
+
         // Detener NexoManager
         if (nexoManager != null) {
             nexoManager.shutdown();
@@ -77,22 +77,22 @@ public class PluginManager {
         if (invasionManager != null) {
             invasionManager.shutdown();
         }
-        
+
         plugin.getLogger().info("§a✅ Todos los managers detenidos correctamente");
     }
-    
+
     /**
      * Recarga todos los managers
      */
     public void reload() {
         plugin.getLogger().info("§6⟳ Recargando todos los managers...");
-        
+
         try {
             // Recargar ConfigManager
             if (configManager != null) {
                 configManager.reloadConfigs();
             }
-            
+
             // Recargar NexoManager
             if (nexoManager != null) {
                 nexoManager.recargarConfiguracion();
@@ -101,23 +101,23 @@ public class PluginManager {
             if (invasionManager != null) {
                 invasionManager.reload(configManager);
             }
-            
+
             plugin.getLogger().info("§a✅ Todos los managers recargados correctamente");
-            
+
         } catch (Exception e) {
             plugin.getLogger().severe("§c❌ Error al recargar managers: " + e.getMessage());
             e.printStackTrace();
         }
     }
-    
+
     // ==========================================
     // GETTERS
     // ==========================================
-    
+
     public ConfigManager getConfigManager() {
         return configManager;
     }
-    
+
     public NexoManager getNexoManager() {
         return nexoManager;
     }
@@ -125,7 +125,7 @@ public class PluginManager {
     public nexo.beta.Events.InvasionManager getInvasionManager() {
         return invasionManager;
     }
-    
+
     public NexoAndCorruption getPlugin() {
         return plugin;
     }

--- a/src/main/java/nexo/beta/utils/Utils.java
+++ b/src/main/java/nexo/beta/utils/Utils.java
@@ -5,7 +5,7 @@ import java.util.regex.Pattern;
 import net.md_5.bungee.api.ChatColor;
 
 public class Utils {
-    
+
     public static String colorize(String msg) {
         Matcher match = Pattern.compile("#[a-fA-F0-9]{6}").matcher(msg);
         while (match.find()) {
@@ -35,6 +35,6 @@ public class Utils {
         if (seconds > 0 || sb.length() == 0) sb.append(seconds).append("s");
         return sb.toString().trim();
     }
-    
+
     // Add more utility methods here
 }

--- a/src/main/resources/nexo.yml
+++ b/src/main/resources/nexo.yml
@@ -7,24 +7,24 @@ nexo:
   vida_maxima: 1000
   energia_maxima: 1000
   energia_consumo_por_minuto: 10
-  
+
   # Radio de protección (en bloques)
   radio_proteccion: 50
-  
+
   # Configuración de ubicación
   ubicacion:
     mundo: "world"
     x: 0
     y: 100
     z: 0
-    
+
   # Sistema de reinicio automático
   reinicio:
     habilitado: true
     aleatorio: true
     intervalo_min: 3600   # 1 hora en segundos
     intervalo_max: 10800  # 3 horas en segundos
-    
+
     # Advertencias antes del reinicio
     advertencias:
       - tiempo: 300  # 5 minutos antes
@@ -56,22 +56,22 @@ nexo:
   eventos_especiales:
     habilitado: true
     probabilidad: 0.25  # 25% de probabilidad
-    
+
     # Mensajes de evento especial
     mensaje_previo: "‼️ El Nexo siente una gran perturbación en la energía..."
     mensaje_inicio: "🔥 ¡INVASIÓN ESPECIAL ACTIVADA! Las defensas del Nexo han fallado."
     mensaje_fin: "✅ El Nexo ha recuperado su estabilidad. La invasión ha terminado."
-    
+
     # Duración del evento especial (en segundos)
     duracion: 1200  # 20 minutos
-    
+
     # Efectos durante el evento
     efectos:
       - tipo: "WEAKNESS"
         duracion: 600  # 10 minutos
         amplificador: 1
         area_radio: 100
-        
+
       - tipo: "SLOWNESS"
         duracion: 300  # 5 minutos
         amplificador: 0
@@ -96,13 +96,13 @@ nexo:
       habilitado: true
       bloquear: true
       mensaje: "🛡️ El Nexo protege esta área de explosiones."
-      
+
     # Protección contra PvP
     pvp:
       habilitado: true
       bloquear: true
       mensaje: "⚔️ El Nexo no permite combate en esta zona protegida."
-      
+
     # Protección contra construcción/destrucción
     bloques:
       habilitado: true
@@ -122,7 +122,7 @@ nexo:
     habilitado: true
     energia_por_segundo: 2
     vida_por_segundo: 1
-    
+
     # Condiciones para regeneración
     requiere_jugadores_cerca: false
     radio_minimo_jugadores: 20
@@ -135,13 +135,13 @@ nexo:
       tipo: "ENCHANTMENT_TABLE"
       cantidad: 10
       intervalo: 5  # segundos
-      
+
     sonidos:
       habilitado: true
       energia_baja: "BLOCK_NOTE_BLOCK_BASS"
       vida_baja: "ENTITY_VILLAGER_HURT"
       reinicio: "BLOCK_END_PORTAL_SPAWN"
-      
+
   # Configuración de estados críticos
   estados_criticos:
     # Cuando la vida está baja
@@ -151,13 +151,13 @@ nexo:
       intervalo_mensaje: 30  # segundos entre mensajes
       efectos:
         - "BLINDNESS:1:10"  # Ceguera nivel 1 por 10 segundos a jugadores cercanos
-        
+
     # Cuando la energía está baja
     energia_baja:
       porcentaje: 20  # 20% de energía o menos
       mensaje: "⚡ El Nexo tiene poca energía ({energia}/{energia_maxima}). Las protecciones se debilitan."
       intervalo_mensaje: 45
-      
+
     # Cuando el Nexo está inactivo
     nexo_inactivo:
       mensaje: "💀 ¡EL NEXO HA CAÍDO! Las protecciones han desaparecido."
@@ -174,12 +174,12 @@ nexo:
     estado:
       habilitado: true
       permiso: "nexo.estado"
-      
+
     # Comando para recargar configuración
     recargar:
       habilitado: true
       permiso: "nexo.admin.recargar"
-      
+
     # Comando para forzar reinicio
     reiniciar:
       habilitado: true
@@ -189,25 +189,25 @@ nexo:
   guardado:
     # Intervalo de guardado automático (en segundos)
     intervalo_auto: 300  # 5 minutos
-    
+
     # Guardar al apagar el servidor
     guardar_al_apagar: true
-    
+
     # Archivo de guardado
     archivo: "nexo_data.yml"
 
   # Mensajes personalizables
   mensajes:
     prefijo: "§8[§6Nexo§8] §r"
-    
+
     # Mensajes de estado
     nexo_activado: "§a✅ El Nexo ha sido activado y está protegiendo el área."
     nexo_desactivado: "§c❌ El Nexo ha sido desactivado. ¡Cuidado!"
-    
+
     # Mensajes de información
     estado_vida: "§6Vida del Nexo: §e{vida}§6/§e{vida_maxima} §6({porcentaje}%)"
     estado_energia: "§b⚡ Energía: §e{energia}§b/§e{energia_maxima} §b({porcentaje}%)"
-    
+
     # Mensajes de error
     nexo_no_encontrado: "§cError: No se pudo encontrar el Nexo."
     sin_permisos: "§cNo tienes permisos para usar este comando."

--- a/target/classes/nexo.yml
+++ b/target/classes/nexo.yml
@@ -7,41 +7,41 @@ nexo:
   vida_maxima: 1000
   energia_maxima: 1000
   energia_consumo_por_minuto: 10
-  
+
   # Radio de protección (en bloques)
   radio_proteccion: 50
-  
+
   # Configuración de ubicación
   ubicacion:
     mundo: "world"
     x: 0
     y: 100
     z: 0
-    
+
   # Sistema de reinicio automático
   reinicio:
     habilitado: true
     aleatorio: true
     intervalo_min: 3600   # 1 hora en segundos
     intervalo_max: 10800  # 3 horas en segundos
-    
+
     # Advertencias antes del reinicio
     advertencias:
       - tiempo: 3600  # 1 hora antes
         mensaje: "⏳ El Nexo podría reiniciarse en 1 hora. Prepárense para posibles ataques."
         broadcast: true
         sonido: "BLOCK_NOTE_BLOCK_PLING"
-        
+
       - tiempo: 1800  # 30 minutos antes
         mensaje: "⚠️ El Nexo muestra inestabilidad... 30 minutos restantes."
         broadcast: true
         sonido: "BLOCK_NOTE_BLOCK_BASS"
-        
+
       - tiempo: 600   # 10 minutos antes
         mensaje: "❗ Posible reinicio inminente del Nexo. ¡Últimos preparativos!"
         broadcast: true
         sonido: "ENTITY_ENDER_DRAGON_GROWL"
-        
+
       - tiempo: 60    # 1 minuto antes
         mensaje: "🚨 ¡REINICIO INMINENTE! El Nexo se apagará en 1 minuto."
         broadcast: true
@@ -51,22 +51,22 @@ nexo:
   eventos_especiales:
     habilitado: true
     probabilidad: 0.25  # 25% de probabilidad
-    
+
     # Mensajes de evento especial
     mensaje_previo: "‼️ El Nexo siente una gran perturbación en la energía..."
     mensaje_inicio: "🔥 ¡INVASIÓN ESPECIAL ACTIVADA! Las defensas del Nexo han fallado."
     mensaje_fin: "✅ El Nexo ha recuperado su estabilidad. La invasión ha terminado."
-    
+
     # Duración del evento especial (en segundos)
     duracion: 1200  # 20 minutos
-    
+
     # Efectos durante el evento
     efectos:
       - tipo: "WEAKNESS"
         duracion: 600  # 10 minutos
         amplificador: 1
         area_radio: 100
-        
+
       - tipo: "SLOWNESS"
         duracion: 300  # 5 minutos
         amplificador: 0
@@ -91,13 +91,13 @@ nexo:
       habilitado: true
       bloquear: true
       mensaje: "🛡️ El Nexo protege esta área de explosiones."
-      
+
     # Protección contra PvP
     pvp:
       habilitado: true
       bloquear: true
       mensaje: "⚔️ El Nexo no permite combate en esta zona protegida."
-      
+
     # Protección contra construcción/destrucción
     bloques:
       habilitado: true
@@ -117,7 +117,7 @@ nexo:
     habilitado: true
     energia_por_segundo: 2
     vida_por_segundo: 1
-    
+
     # Condiciones para regeneración
     requiere_jugadores_cerca: false
     radio_minimo_jugadores: 20
@@ -130,13 +130,13 @@ nexo:
       tipo: "ENCHANTMENT_TABLE"
       cantidad: 10
       intervalo: 5  # segundos
-      
+
     sonidos:
       habilitado: true
       energia_baja: "BLOCK_NOTE_BLOCK_BASS"
       vida_baja: "ENTITY_VILLAGER_HURT"
       reinicio: "BLOCK_END_PORTAL_SPAWN"
-      
+
   # Configuración de estados críticos
   estados_criticos:
     # Cuando la vida está baja
@@ -146,13 +146,13 @@ nexo:
       intervalo_mensaje: 30  # segundos entre mensajes
       efectos:
         - "BLINDNESS:1:10"  # Ceguera nivel 1 por 10 segundos a jugadores cercanos
-        
+
     # Cuando la energía está baja
     energia_baja:
       porcentaje: 20  # 20% de energía o menos
       mensaje: "⚡ El Nexo tiene poca energía ({energia}/{energia_maxima}). Las protecciones se debilitan."
       intervalo_mensaje: 45
-      
+
     # Cuando el Nexo está inactivo
     nexo_inactivo:
       mensaje: "💀 ¡EL NEXO HA CAÍDO! Las protecciones han desaparecido."
@@ -169,12 +169,12 @@ nexo:
     estado:
       habilitado: true
       permiso: "nexo.estado"
-      
+
     # Comando para recargar configuración
     recargar:
       habilitado: true
       permiso: "nexo.admin.recargar"
-      
+
     # Comando para forzar reinicio
     reiniciar:
       habilitado: true
@@ -184,25 +184,25 @@ nexo:
   guardado:
     # Intervalo de guardado automático (en segundos)
     intervalo_auto: 300  # 5 minutos
-    
+
     # Guardar al apagar el servidor
     guardar_al_apagar: true
-    
+
     # Archivo de guardado
     archivo: "nexo_data.yml"
 
   # Mensajes personalizables
   mensajes:
     prefijo: "§8[§6Nexo§8] §r"
-    
+
     # Mensajes de estado
     nexo_activado: "§a✅ El Nexo ha sido activado y está protegiendo el área."
     nexo_desactivado: "§c❌ El Nexo ha sido desactivado. ¡Cuidado!"
-    
+
     # Mensajes de información
     estado_vida: "§6Vida del Nexo: §e{vida}§6/§e{vida_maxima} §6({porcentaje}%)"
     estado_energia: "§b⚡ Energía: §e{energia}§b/§e{energia_maxima} §b({porcentaje}%)"
-    
+
     # Mensajes de error
     nexo_no_encontrado: "§cError: No se pudo encontrar el Nexo."
     sin_permisos: "§cNo tienes permisos para usar este comando."


### PR DESCRIPTION
## Summary
- clean up indentation and trailing spaces in `nexo.yml`
- add missing newline at EOF for the config
- remove trailing whitespace from Java files to tidy code

## Testing
- `mvn -q test` *(fails: `mvn` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685441dc803483308faa8ced06db2357