### PR TITLE
Automatic restart probability

### DIFF
--- a/src/main/java/nexo/beta/managers/ConfigManager.java
+++ b/src/main/java/nexo/beta/managers/ConfigManager.java
@@ -97,11 +97,15 @@ public class ConfigManager {
     }
 
     public int getIntervaloReinicioMin() {
-        return nexoConfig.getInt("nexo.reinicio.intervalo_min", 3600);
+        return nexoConfig.getInt("nexo.reinicio.intervalo_min", 1);
     }
 
     public int getIntervaloReinicioMax() {
-        return nexoConfig.getInt("nexo.reinicio.intervalo_max", 10800);
+        return nexoConfig.getInt("nexo.reinicio.intervalo_max", 5);
+    }
+
+    public double getProbabilidadBaseReinicio() {
+        return nexoConfig.getDouble("nexo.reinicio.probabilidad_base", 0.1);
     }
 
     public List<Map<?, ?>> getAdvertenciasReinicio() {

--- a/src/main/resources/nexo.yml
+++ b/src/main/resources/nexo.yml
@@ -22,8 +22,11 @@ nexo:
   reinicio:
     habilitado: true
     aleatorio: true
-    intervalo_min: 3600   # 1 hora en segundos
-    intervalo_max: 10800  # 3 horas en segundos
+    # Intervalos en minutos para programar revisiones de reinicio
+    intervalo_min: 1      # Mínimo 1 minuto
+    intervalo_max: 5      # Máximo 5 minutos
+    # Probabilidad base de que ocurra un reinicio cuando la batería está llena
+    probabilidad_base: 0.1
 
     # Advertencias antes del reinicio
     advertencias:


### PR DESCRIPTION
## Summary
- add configurable probabilistic restart system
- schedule restart checks between 1 and 5 minutes based on battery level
- update defaults in `nexo.yml`

## Testing
- `mvn -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685462fb92048330a2a1aa60c92c8dd8