### PR TITLE
Force indefinite invasion until nexus activation

### DIFF
--- a/src/main/java/nexo/beta/Events/InvasionManager.java
+++ b/src/main/java/nexo/beta/Events/InvasionManager.java
@@ -92,8 +92,7 @@ public class InvasionManager {
         } else if (invasionInfinita) {
             boolean finalizar = true;
             for (Nexo nexo : nexoManager.getTodosLosNexos().values()) {
-                if (nexo.estaReiniciando() || !nexo.estaActivo() ||
-                    nexo.getEnergia() < config.getEnergiaMaxima() / 2) {
+                if (!nexo.estaActivo()) {
                     finalizar = false;
                     break;
                 }


### PR DESCRIPTION
## Summary
- ensure endless invasion only ends when all nexuses are active

## Testing
- `mvn test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854671afe388330944da0e454e08037