### PR TITLE
Ajustar intervalo de reinicio a 30s-1m

### DIFF
--- a/src/main/resources/nexo.yml
+++ b/src/main/resources/nexo.yml
@@ -23,10 +23,10 @@ nexo:
     habilitado: true
     aleatorio: true
     # Intervalos en minutos para programar revisiones de reinicio
-    intervalo_min: 1      # Mínimo 1 minuto
-    intervalo_max: 5      # Máximo 5 minutos
+    intervalo_min: 0.5      # Mínimo 30 segundos
+    intervalo_max: 1        # Máximo 1 minuto
     # Probabilidad base de que ocurra un reinicio cuando la batería está llena
-    probabilidad_base: 0.1
+    probabilidad_base: 0.3
 
     # Advertencias antes del reinicio
     advertencias:


### PR DESCRIPTION
## Summary
- reduce `intervalo_min` to 0.5 (30s)
- reduce `intervalo_max` to 1 (1m)
- set `probabilidad_base` to 0.3

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854ab733918833087cfec845e60b275