### PR TITLE
Replace restart logic with invasion

### DIFF
--- a/src/main/java/nexo/beta/CommandManager/CommandNexoManager.java
+++ b/src/main/java/nexo/beta/CommandManager/CommandNexoManager.java
@@ -99,13 +99,8 @@ public class CommandNexoManager implements CommandExecutor {
                     sender.sendMessage("§cComando deshabilitado.");
                     return true;
                 }
-                Nexo nexoRei = nexoManager.getNexoEnMundo(sender instanceof Player p ? p.getWorld() : plugin.getServer().getWorlds().get(0));
-                if (nexoRei == null) {
-                    sender.sendMessage(config.getMensajeNexoNoEncontrado());
-                    return true;
-                }
-                nexoRei.reiniciar();
-                sender.sendMessage("§aNexo reiniciado.");
+                plugin.getPluginManager().getInvasionManager().forzarInvasion();
+                sender.sendMessage("§aEl Nexo se está reiniciando...");
                 break;
             case "expandir":
                 if (args.length < 2) {

--- a/src/main/java/nexo/beta/Events/InvasionManager.java
+++ b/src/main/java/nexo/beta/Events/InvasionManager.java
@@ -73,20 +73,14 @@ public class InvasionManager {
     private void verificarCondiciones() {
         if (!invasionActiva) {
             for (Nexo nexo : nexoManager.getTodosLosNexos().values()) {
-                if (nexo.estaReiniciando()) {
-                    iniciarInvasion(nexo.getTiempoReinicioRestante());
-                    return;
-                }
                 if (!nexo.estaActivo()) {
                     iniciarInvasion(-1);
                     return;
                 }
-                if (nexo.estaActivo()) {
-                    double prob = 0.9 * (1.0 - ((double) nexo.getEnergia() / config.getEnergiaMaxima()));
-                    if (Math.random() <= prob) {
-                        nexo.reiniciar();
-                        return;
-                    }
+                double prob = 0.9 * (1.0 - ((double) nexo.getEnergia() / config.getEnergiaMaxima()));
+                if (Math.random() <= prob) {
+                    iniciarCuentaRegresiva();
+                    return;
                 }
             }
         } else if (invasionInfinita) {
@@ -164,6 +158,12 @@ public class InvasionManager {
             }
         }
         estadoPrevio.clear();
+    }
+
+    public void detenerInvasion() {
+        if (invasionActiva) {
+            finalizarInvasion();
+        }
     }
 
     private void generarEntidades() {

--- a/src/main/java/nexo/beta/NexoAndCorruption.java
+++ b/src/main/java/nexo/beta/NexoAndCorruption.java
@@ -98,7 +98,6 @@ public class NexoAndCorruption extends JavaPlugin {
         getLogger().info("§e[DEBUG] Ubicación del Nexo: " + config.getUbicacionNexo().toString());
         getLogger().info("§e[DEBUG] Nexos activos: " + nexo.getNexosActivos() + "/" + nexo.getTotalNexos());
         getLogger().info("§e[DEBUG] Regeneración habilitada: " + config.isRegeneracionHabilitada());
-        getLogger().info("§e[DEBUG] Reinicio automático: " + config.isReinicioHabilitado());
         getLogger().info("§e[DEBUG] Eventos especiales: " + config.isEventosEspecialesHabilitado());
         getLogger().info("§e[DEBUG] ==========================================");
     }

--- a/src/main/java/nexo/beta/managers/ConfigManager.java
+++ b/src/main/java/nexo/beta/managers/ConfigManager.java
@@ -85,34 +85,6 @@ public class ConfigManager {
     }
 
     // ==========================================
-    // MÉTODOS PARA SISTEMA DE REINICIO
-    // ==========================================
-
-    public boolean isReinicioHabilitado() {
-        return nexoConfig.getBoolean("nexo.reinicio.habilitado", true);
-    }
-
-    public boolean isReinicioAleatorio() {
-        return nexoConfig.getBoolean("nexo.reinicio.aleatorio", true);
-    }
-
-    public int getIntervaloReinicioMin() {
-        return nexoConfig.getInt("nexo.reinicio.intervalo_min", 1);
-    }
-
-    public int getIntervaloReinicioMax() {
-        return nexoConfig.getInt("nexo.reinicio.intervalo_max", 5);
-    }
-
-    public double getProbabilidadBaseReinicio() {
-        return nexoConfig.getDouble("nexo.reinicio.probabilidad_base", 0.1);
-    }
-
-    public List<Map<?, ?>> getAdvertenciasReinicio() {
-        return nexoConfig.getMapList("nexo.reinicio.advertencias");
-    }
-
-    // ==========================================
     // MÉTODOS PARA EVENTOS ESPECIALES
     // ==========================================
 

--- a/src/main/java/nexo/beta/managers/NexoManager.java
+++ b/src/main/java/nexo/beta/managers/NexoManager.java
@@ -29,7 +29,6 @@ public class NexoManager {
     private BukkitTask taskRegeneracion;
     private BukkitTask taskConsumoEnergia;
     private BukkitTask taskGuardadoAutomatico;
-    private BukkitTask taskReinicioProgramado;
 
     private NexoManager(NexoAndCorruption plugin, ConfigManager configManager) {
         this.plugin = plugin;
@@ -129,10 +128,6 @@ public class NexoManager {
             }.runTaskTimer(plugin, intervalo, intervalo);
         }
 
-        if (configManager.isReinicioHabilitado()) {
-            programarReinicio();
-        }
-
         logger.info("§a✅ Tareas automáticas del Nexo iniciadas");
     }
 
@@ -151,9 +146,6 @@ public class NexoManager {
         }
         if (taskGuardadoAutomatico != null && !taskGuardadoAutomatico.isCancelled()) {
             taskGuardadoAutomatico.cancel();
-        }
-        if (taskReinicioProgramado != null && !taskReinicioProgramado.isCancelled()) {
-            taskReinicioProgramado.cancel();
         }
 
         // Guardar todos los Nexos antes de cerrar
@@ -302,35 +294,6 @@ public class NexoManager {
     /**
      * Programa una verificación de reinicio de acuerdo a la configuración.
      */
-    private void programarReinicio() {
-        int min = configManager.getIntervaloReinicioMin();
-        int max = configManager.getIntervaloReinicioMax();
-        int intervalo = min;
-        if (max > min) {
-            intervalo = min + (int) (Math.random() * (max - min + 1));
-        }
-        long ticks = intervalo * 60L * 20L; // minutos a ticks
-        taskReinicioProgramado = new BukkitRunnable() {
-            @Override
-            public void run() {
-                verificarReinicioProbabilistico();
-                programarReinicio();
-            }
-        }.runTaskLater(plugin, ticks);
-    }
-
-    private void verificarReinicioProbabilistico() {
-        double base = configManager.getProbabilidadBaseReinicio();
-        for (Nexo nexo : nexosPorMundo.values()) {
-            if (!nexo.estaActivo() || nexo.estaReiniciando()) continue;
-            double energia = (double) nexo.getEnergia() / configManager.getEnergiaMaxima();
-            double prob = base * (1 + (1 - energia));
-            if (Math.random() <= prob) {
-                Bukkit.broadcastMessage(configManager.getPrefijo() + "⏳ El Nexo se reiniciará en 5 minutos.");
-                nexo.reiniciar();
-            }
-        }
-    }
 
     // ==========================================
     // MÉTODOS DE GUARDADO Y CARGA
@@ -364,9 +327,6 @@ public class NexoManager {
         }
         if (taskGuardadoAutomatico != null && !taskGuardadoAutomatico.isCancelled()) {
             taskGuardadoAutomatico.cancel();
-        }
-        if (taskReinicioProgramado != null && !taskReinicioProgramado.isCancelled()) {
-            taskReinicioProgramado.cancel();
         }
 
         // Recargar configuración de todos los Nexos

--- a/src/main/resources/nexo.yml
+++ b/src/main/resources/nexo.yml
@@ -18,43 +18,6 @@ nexo:
     y: 100
     z: 0
 
-  # Sistema de reinicio automático
-  reinicio:
-    habilitado: true
-    aleatorio: true
-    # Intervalos en minutos para programar revisiones de reinicio
-    intervalo_min: 0.5      # Mínimo 30 segundos
-    intervalo_max: 1        # Máximo 1 minuto
-    # Probabilidad base de que ocurra un reinicio cuando la batería está llena
-    probabilidad_base: 0.3
-
-    # Advertencias antes del reinicio
-    advertencias:
-      - tiempo: 300  # 5 minutos antes
-        mensaje: "⏳ El Nexo se reiniciará en 5 minutos."
-        broadcast: true
-        sonido: "BLOCK_NOTE_BLOCK_PLING"
-
-      - tiempo: 240  # 4 minutos antes
-        mensaje: "⚠️ Reinicio del Nexo en 4 minutos."
-        broadcast: true
-        sonido: "BLOCK_NOTE_BLOCK_BASS"
-
-      - tiempo: 180  # 3 minutos antes
-        mensaje: "❗ Reinicio del Nexo en 3 minutos."
-        broadcast: true
-        sonido: "ENTITY_ENDER_DRAGON_GROWL"
-
-      - tiempo: 120  # 2 minutos antes
-        mensaje: "❗ Reinicio del Nexo en 2 minutos."
-        broadcast: true
-        sonido: "ENTITY_ENDER_DRAGON_GROWL"
-
-      - tiempo: 60    # 1 minuto antes
-        mensaje: "🚨 ¡REINICIO INMINENTE! El Nexo se apagará en 1 minuto."
-        broadcast: true
-        sonido: "BLOCK_END_PORTAL_SPAWN"
-
   # Eventos especiales durante el reinicio
   eventos_especiales:
     habilitado: true
@@ -62,7 +25,7 @@ nexo:
 
     # Mensajes de evento especial
     mensaje_previo: "‼️ El Nexo siente una gran perturbación en la energía..."
-    mensaje_inicio: "🔥 ¡INVASIÓN ESPECIAL ACTIVADA! Las defensas del Nexo han fallado."
+    mensaje_inicio: "El Nexo se está reiniciando..."
     mensaje_fin: "✅ El Nexo ha recuperado su estabilidad. La invasión ha terminado."
 
     # Duración del evento especial (en segundos)


### PR DESCRIPTION
## Summary
- remove obsolete restart configuration from `nexo.yml`
- drop restart-related methods in `ConfigManager`, `NexoManager` and `Nexo`
- reuse invasion manager for manual restart command
- adjust invasion checks and add public stop method
- reactivate nexo when energy >= 50% and stop invasion
- update debug info

## Testing
- `mvn -q test` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6854b34653308330817c5bbbd6bf1212