### PR TITLE
Update invasion handling and cleanup commands

### DIFF
--- a/src/main/java/nexo/beta/CommandManager/CommandNexoManager.java
+++ b/src/main/java/nexo/beta/CommandManager/CommandNexoManager.java
@@ -30,7 +30,7 @@ public class CommandNexoManager implements CommandExecutor {
     @Override
     public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
         if (args.length == 0) {
-            sender.sendMessage("§eUso: /" + label + " <crear|destruir|estado|activar|desactivar|reiniciar|recargar|expandir|invasion>");
+            sender.sendMessage("§eUso: /" + label + " <crear|destruir|estado|activar|desactivar|recargar|expandir|invasion>");
             return true;
         }
 
@@ -94,14 +94,6 @@ public class CommandNexoManager implements CommandExecutor {
                 nexoDes.desactivar();
                 sender.sendMessage("§cNexo desactivado.");
                 break;
-            case "reiniciar":
-                if (!config.isComandoReiniciarHabilitado()) {
-                    sender.sendMessage("§cComando deshabilitado.");
-                    return true;
-                }
-                plugin.getPluginManager().getInvasionManager().forzarInvasion();
-                sender.sendMessage("§aEl Nexo se está reiniciando...");
-                break;
             case "expandir":
                 if (args.length < 2) {
                     sender.sendMessage("§cUso: /" + label + " expandir <cantidad>");
@@ -135,7 +127,7 @@ public class CommandNexoManager implements CommandExecutor {
                 sender.sendMessage("§aPlugin recargado.");
                 break;
             default:
-                sender.sendMessage("§eUso: /" + label + " <crear|destruir|estado|activar|desactivar|reiniciar|recargar|expandir|invasion>");
+                sender.sendMessage("§eUso: /" + label + " <crear|destruir|estado|activar|desactivar|recargar|expandir|invasion>");
                 break;
         }
         return true;

--- a/src/main/java/nexo/beta/Events/InvasionManager.java
+++ b/src/main/java/nexo/beta/Events/InvasionManager.java
@@ -77,7 +77,7 @@ public class InvasionManager {
                     iniciarInvasion(-1);
                     return;
                 }
-                double prob = 0.9 * (1.0 - ((double) nexo.getEnergia() / config.getEnergiaMaxima()));
+                double prob = config.getInvasionProbabilidad();
                 if (Math.random() <= prob) {
                     iniciarCuentaRegresiva();
                     return;
@@ -122,7 +122,7 @@ public class InvasionManager {
         Bukkit.broadcastMessage(Utils.colorize(config.getMensajeInicioEvento()));
         if (!invasionInfinita) {
             Bukkit.broadcastMessage(Utils.colorize(
-                config.getPrefijo() + "La invasión durará " + Utils.formatTime(duracion) + "."));
+                config.getPrefijo() + "La invasión durará " + formatTime(duracion) + "."));
         }
         estadoPrevio.clear();
         for (Nexo nexo : nexoManager.getTodosLosNexos().values()) {
@@ -205,5 +205,21 @@ public class InvasionManager {
             }
         }
         return EntityType.ZOMBIE;
+    }
+
+    private static String formatTime(int seconds) {
+        int days = seconds / 86400;
+        seconds %= 86400;
+        int hours = seconds / 3600;
+        seconds %= 3600;
+        int minutes = seconds / 60;
+        seconds %= 60;
+
+        StringBuilder sb = new StringBuilder();
+        if (days > 0) sb.append(days).append("d ");
+        if (hours > 0) sb.append(hours).append("h ");
+        if (minutes > 0) sb.append(minutes).append("m ");
+        if (seconds > 0 || sb.length() == 0) sb.append(seconds).append("s");
+        return sb.toString().trim();
     }
 }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -6,5 +6,5 @@ api-version: 1.20
 commands:
   nexo:
     description: Gestiona el Nexo protector
-    usage: /<command> <crear|destruir|estado|activar|desactivar|reiniciar|recargar|expandir>
+  usage: /<command> <crear|destruir|estado|activar|desactivar|recargar|expandir>
     permission: nexo.admin


### PR DESCRIPTION
## Summary
- rely on YAML-defined probability when triggering invasions
- show duration with local `formatTime` to avoid missing method issue
- remove the `reiniciar` command

## Testing
- `mvn -q package` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6854b91c0b488330987d6aa58d82d6fc