### PR TITLE
Adjust invasion mechanics and remove special event

### DIFF
--- a/src/main/java/nexo/beta/Events/InvasionManager.java
+++ b/src/main/java/nexo/beta/Events/InvasionManager.java
@@ -38,7 +38,7 @@ public class InvasionManager {
     }
 
     public void start() {
-        long intervalo = 20L; // comprobar cada segundo
+        long intervalo = config.getInvasionCheckInterval() * 20L; // convertir segundos a ticks
         checkTask = new BukkitRunnable() {
             @Override
             public void run() {
@@ -72,27 +72,9 @@ public class InvasionManager {
 
     private void verificarCondiciones() {
         if (!invasionActiva) {
-            for (Nexo nexo : nexoManager.getTodosLosNexos().values()) {
-                if (!nexo.estaActivo()) {
-                    iniciarInvasion(-1);
-                    return;
-                }
-                double prob = config.getInvasionProbabilidad();
-                if (Math.random() <= prob) {
-                    iniciarCuentaRegresiva();
-                    return;
-                }
-            }
-        } else if (invasionInfinita) {
-            boolean finalizar = true;
-            for (Nexo nexo : nexoManager.getTodosLosNexos().values()) {
-                if (!nexo.estaActivo()) {
-                    finalizar = false;
-                    break;
-                }
-            }
-            if (finalizar) {
-                finalizarInvasion();
+            double prob = config.getInvasionProbabilidad();
+            if (Math.random() <= prob) {
+                iniciarCuentaRegresiva();
             }
         }
     }
@@ -177,7 +159,7 @@ public class InvasionManager {
 
             double angulo = rnd.nextDouble() * 2 * Math.PI;
             int maxDist = config.getInvasionRadioSpawn();
-            int minDist = config.getRadioProteccion();
+            int minDist = config.getInvasionRadioSpawnMin();
             double distancia = minDist + rnd.nextDouble() * (maxDist - minDist);
             double x = centro.getX() + Math.cos(angulo) * distancia;
             double z = centro.getZ() + Math.sin(angulo) * distancia;

--- a/src/main/java/nexo/beta/NexoAndCorruption.java
+++ b/src/main/java/nexo/beta/NexoAndCorruption.java
@@ -98,7 +98,7 @@ public class NexoAndCorruption extends JavaPlugin {
         getLogger().info("§e[DEBUG] Ubicación del Nexo: " + config.getUbicacionNexo().toString());
         getLogger().info("§e[DEBUG] Nexos activos: " + nexo.getNexosActivos() + "/" + nexo.getTotalNexos());
         getLogger().info("§e[DEBUG] Regeneración habilitada: " + config.isRegeneracionHabilitada());
-        getLogger().info("§e[DEBUG] Eventos especiales: " + config.isEventosEspecialesHabilitado());
+        getLogger().info("§e[DEBUG] Intervalo de verificación de invasiones: " + config.getInvasionCheckInterval() + "s");
         getLogger().info("§e[DEBUG] ==========================================");
     }
 

--- a/src/main/java/nexo/beta/managers/ConfigManager.java
+++ b/src/main/java/nexo/beta/managers/ConfigManager.java
@@ -85,43 +85,23 @@ public class ConfigManager {
     }
 
     // ==========================================
-    // MÉTODOS PARA EVENTOS ESPECIALES
+    // MÉTODOS PARA INVASIONES
     // ==========================================
 
-    public boolean isEventosEspecialesHabilitado() {
-        return nexoConfig.getBoolean("nexo.eventos_especiales.habilitado", true);
-    }
-
-    public double getProbabilidadEventoEspecial() {
-        return nexoConfig.getDouble("nexo.eventos_especiales.probabilidad", 0.25);
-    }
-
     public String getMensajePrevioEvento() {
-        return nexoConfig.getString("nexo.eventos_especiales.mensaje_previo",
+        return nexoConfig.getString("nexo.invasion.mensaje_previo",
             "‼️ El Nexo siente una gran perturbación en la energía...");
     }
 
     public String getMensajeInicioEvento() {
-        return nexoConfig.getString("nexo.eventos_especiales.mensaje_inicio",
-            "🔥 ¡INVASIÓN ESPECIAL ACTIVADA! Las defensas del Nexo han fallado.");
+        return nexoConfig.getString("nexo.invasion.mensaje_inicio",
+            "🔥 ¡INVASIÓN ACTIVADA! Las defensas del Nexo han fallado.");
     }
 
     public String getMensajeFinEvento() {
-        return nexoConfig.getString("nexo.eventos_especiales.mensaje_fin",
+        return nexoConfig.getString("nexo.invasion.mensaje_fin",
             "✅ El Nexo ha recuperado su estabilidad. La invasión ha terminado.");
     }
-
-    public int getDuracionEventoEspecial() {
-        return nexoConfig.getInt("nexo.eventos_especiales.duracion", 1200);
-    }
-
-    public List<Map<?, ?>> getEfectosEventoEspecial() {
-        return nexoConfig.getMapList("nexo.eventos_especiales.efectos");
-    }
-
-    // ==========================================
-    // MÉTODOS PARA INVASIONES
-    // ==========================================
 
     public double getInvasionProbabilidad() {
         return nexoConfig.getDouble("nexo.invasion.probabilidad", 0.1);
@@ -137,6 +117,14 @@ public class ConfigManager {
 
     public int getInvasionRadioSpawn() {
         return nexoConfig.getInt("nexo.invasion.radio_spawn", 100);
+    }
+
+    public int getInvasionRadioSpawnMin() {
+        return nexoConfig.getInt("nexo.invasion.radio_spawn_min", 80);
+    }
+
+    public int getInvasionCheckInterval() {
+        return nexoConfig.getInt("nexo.invasion.check_interval", 60);
     }
 
     public Map<String, Double> getInvasionMobs() {

--- a/src/main/resources/nexo.yml
+++ b/src/main/resources/nexo.yml
@@ -18,42 +18,23 @@ nexo:
     y: 100
     z: 0
 
-  # Eventos especiales durante el reinicio
-  eventos_especiales:
-    habilitado: true
-    probabilidad: 0.25  # 25% de probabilidad
-
-    # Mensajes de evento especial
-    mensaje_previo: "‼️ El Nexo siente una gran perturbación en la energía..."
-    mensaje_inicio: "El Nexo se está reiniciando..."
-    mensaje_fin: "✅ El Nexo ha recuperado su estabilidad. La invasión ha terminado."
-
-    # Duración del evento especial (en segundos)
-    duracion: 1200  # 20 minutos
-
-    # Efectos durante el evento
-    efectos:
-      - tipo: "WEAKNESS"
-        duracion: 600  # 10 minutos
-        amplificador: 1
-        area_radio: 100
-
-      - tipo: "SLOWNESS"
-        duracion: 300  # 5 minutos
-        amplificador: 0
-        area_radio: 75
-
-  # Configuración de invasiones aleatorias
+  # Configuración de invasiones
   invasion:
     probabilidad: 1.0          # Probabilidad de que ocurra la invasión
     advertencia: 30            # Segundos de aviso antes de iniciar
     duracion: 30               # Duración de la invasión en segundos
     radio_spawn: 100           # Radio máximo para spawnear criaturas
+    radio_spawn_min: 80        # Distancia mínima para spawnear criaturas
+    check_interval: 60         # Intervalo para evaluar una invasión (en segundos)
+    mensaje_previo: "‼️ El Nexo siente una gran perturbación en la energía..."
+    mensaje_inicio: "El Nexo se está reiniciando..."
+    mensaje_fin: "✅ El Nexo ha recuperado su estabilidad. La invasión ha terminado."
     mobs:
       ZOMBIE: 0.4
       SKELETON: 0.3
       CREEPER: 0.2
       WARDEN: 0.1
+
 
   # Sistema de protecciones
   protecciones:


### PR DESCRIPTION
## Summary
- remove unused special invasion event configuration
- add new invasion configuration options (`radio_spawn_min` and `check_interval`)
- update `InvasionManager` to use the new check interval and spawn distance
- update debug info and configuration manager helpers

## Testing
- `mvn -q test` *(fails: mvn not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6854becb499c8330bbe662356ec5e718