### PR TITLE
Improve invasion warnings and damage effects

### DIFF
--- a/src/main/java/nexo/beta/Events/InvasionManager.java
+++ b/src/main/java/nexo/beta/Events/InvasionManager.java
@@ -105,7 +105,11 @@ public class InvasionManager {
     private void iniciarInvasion(int duracion) {
         invasionActiva = true;
         invasionInfinita = duracion < 0;
+        Bukkit.broadcastMessage(Utils.colorize(config.getMensajeInvasionActivada()));
         Bukkit.broadcastMessage(Utils.colorize(config.getMensajeInicioEvento()));
+        for (org.bukkit.entity.Player p : Bukkit.getOnlinePlayers()) {
+            p.playSound(p.getLocation(), org.bukkit.Sound.ENTITY_WITHER_SPAWN, 1.0f, 1.0f);
+        }
         if (!invasionInfinita) {
             Bukkit.broadcastMessage(Utils.colorize(
                 config.getPrefijo() + "La invasión durará " + formatTime(duracion) + "."));
@@ -126,6 +130,12 @@ public class InvasionManager {
                         finalizarInvasion();
                         cancel();
                         return;
+                    }
+                    if (tiempo <= 5) {
+                        for (org.bukkit.entity.Player p : Bukkit.getOnlinePlayers()) {
+                            p.playSound(p.getLocation(), org.bukkit.Sound.BLOCK_NOTE_BLOCK_PLING, 1.0f, 1.5f);
+                            p.spawnParticle(org.bukkit.Particle.SMOKE_NORMAL, p.getLocation().add(0,1,0), 10, 0.5, 0.5, 0.5, 0.01);
+                        }
                     }
                     tiempo--;
                 }

--- a/src/main/java/nexo/beta/classes/Nexo.java
+++ b/src/main/java/nexo/beta/classes/Nexo.java
@@ -381,6 +381,34 @@ public class Nexo {
     }
 
     /**
+     * Muestra efectos de daño al Nexo
+     */
+    private void mostrarDanio() {
+        if (ubicacion.getWorld() == null) return;
+
+        ubicacion.getWorld().spawnParticle(Particle.DAMAGE_INDICATOR,
+                ubicacion.clone().add(0, 1, 0), 10, 0.2, 0.2, 0.2, 0.1);
+
+        if (configManager.isSonidosHabilitados()) {
+            for (Player player : ubicacion.getWorld().getPlayers()) {
+                player.playSound(player.getLocation(), Sound.ENTITY_GENERIC_HURT,
+                        1.0f, 1.0f);
+            }
+        }
+
+        Map<String, Object> placeholders = new HashMap<>();
+        placeholders.put("vida", vida);
+        placeholders.put("vida_maxima", configManager.getVidaMaxima());
+        String msg = configManager.replacePlaceholders(
+                configManager.getMensajeNexoDanado(), placeholders);
+        Bukkit.broadcastMessage(msg);
+
+        if (estaVidaBaja()) {
+            enviarMensajeVidaBaja();
+        }
+    }
+
+    /**
      * Verifica si hay jugadores cerca del Nexo
      */
     public boolean hayJugadoresCerca(int radio, int minimoJugadores) {
@@ -556,6 +584,7 @@ public class Nexo {
     }
 
     public void setVida(int vida) {
+        int vidaAnterior = this.vida;
         this.vida = Math.max(0, Math.min(vida, configManager.getVidaMaxima()));
 
         if (warden != null && !warden.isDead()) {
@@ -563,10 +592,13 @@ public class Nexo {
             warden.setHealth(Math.max(0.0, Math.min(this.vida, max)));
         }
 
-        // Si la vida llega a 0, desactivar el Nexo
+        if (vidaAnterior > this.vida) {
+            mostrarDanio();
+        }
+
+        // Si la vida llega a 0, destruir por completo
         if (this.vida <= 0 && activo) {
-            desactivar();
-            destroyRepresentation();
+            destruir();
         }
     }
 

--- a/src/main/java/nexo/beta/managers/ConfigManager.java
+++ b/src/main/java/nexo/beta/managers/ConfigManager.java
@@ -377,6 +377,16 @@ public class ConfigManager {
             "§c❌ El Nexo ha sido desactivado. ¡Cuidado!");
     }
 
+    public String getMensajeNexoDanado() {
+        return getPrefijo() + nexoConfig.getString("nexo.mensajes.nexo_danado",
+                "§c⚠️ ¡El Nexo está siendo atacado! ({vida}/{vida_maxima})");
+    }
+
+    public String getMensajeInvasionActivada() {
+        return getPrefijo() + nexoConfig.getString("nexo.mensajes.invasion_activada",
+                "§4⚠️ ¡La invasión ha comenzado!");
+    }
+
     public String getMensajeEstadoVida() {
         return nexoConfig.getString("nexo.mensajes.estado_vida",
             "§6Vida del Nexo: §e{vida}§6/§e{vida_maxima} §6({porcentaje}%)");

--- a/src/main/java/nexo/beta/utils/BarrierUtils.java
+++ b/src/main/java/nexo/beta/utils/BarrierUtils.java
@@ -213,8 +213,9 @@ public class BarrierUtils {
 
         if (!isActive) {
             color = Color.GRAY;
-            density = 600;
-            createPulseBarrier(nexoId + "_barrier", center, radius, particle, color);
+            density = 1000; // más partículas cuando está desactivado
+            createAdvancedBarrier(nexoId + "_barrier", center, radius, particle,
+                    color, density, false, true, 4);
         } else if (isCritical) {
             color = Color.RED;
             density = 500;

--- a/src/main/resources/nexo.yml
+++ b/src/main/resources/nexo.yml
@@ -31,16 +31,17 @@ nexo:
     mensaje_fin: "✅ El Nexo ha recuperado su estabilidad. La invasión ha terminado."
     mobs:
       ZOMBIE: 0.2
-      SKELETON: 0.15
-      WITHER_SKELETON: 0.05
+      SKELETON: 0.2
+      WITHER_SKELETON: 0.1
       HUSK: 0.1
       STRAY: 0.1
       DROWNED: 0.1
       SPIDER: 0.08
       CAVE_SPIDER: 0.05
       CREEPER: 0.15
-      WITHER: 0.01
-      WARDEN: 0.01
+      WITHER: 0.001
+      WARDEN: 0.001
+      GIANT: 0.001
 
 
 
@@ -158,6 +159,8 @@ nexo:
     # Mensajes de estado
     nexo_activado: "§a✅ El Nexo ha sido activado y está protegiendo el área."
     nexo_desactivado: "§c❌ El Nexo ha sido desactivado. ¡Cuidado!"
+    nexo_danado: "§c⚠️ ¡El Nexo está siendo atacado! ({vida}/{vida_maxima})"
+    invasion_activada: "§4⚠️ ¡La invasión ha comenzado!"
 
     # Mensajes de información
     estado_vida: "§6Vida del Nexo: §e{vida}§6/§e{vida_maxima} §6({porcentaje}%)"


### PR DESCRIPTION
## Summary
- show more particles when the barrier is inactive
- add warnings and sounds when the nexo takes damage or an invasion starts
- remove the nexo completely when its life reaches zero
- tweak invasion mob probabilities

## Testing
- `mvn -q -DskipTests package` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854d185b3a883308a8a8b6dc3fd2c6e