### PR TITLE
Enhance nexo persistence and destruction

### DIFF
--- a/src/main/java/nexo/beta/classes/Nexo.java
+++ b/src/main/java/nexo/beta/classes/Nexo.java
@@ -409,6 +409,17 @@ public class Nexo {
     }
 
     /**
+     * Muestra un destello y sonido de explosión al destruirse el Nexo
+     */
+    private void mostrarDestruccion() {
+        if (ubicacion.getWorld() == null) return;
+
+        ubicacion.getWorld().spawnParticle(Particle.FLASH, ubicacion, 50, 1, 1, 1, 0);
+        ubicacion.getWorld().spawnParticle(Particle.EXPLOSION_HUGE, ubicacion, 1);
+        ubicacion.getWorld().playSound(ubicacion, Sound.ENTITY_GENERIC_EXPLODE, 2.0f, 1.0f);
+    }
+
+    /**
      * Verifica si hay jugadores cerca del Nexo
      */
     public boolean hayJugadoresCerca(int radio, int minimoJugadores) {
@@ -596,9 +607,15 @@ public class Nexo {
             mostrarDanio();
         }
 
-        // Si la vida llega a 0, destruir por completo
+        // Si la vida llega a 0, eliminar el Nexo por completo
         if (this.vida <= 0 && activo) {
-            destruir();
+            mostrarDestruccion();
+            nexo.beta.managers.NexoManager manager = nexo.beta.managers.NexoManager.getInstance();
+            if (manager != null) {
+                manager.eliminarNexo(ubicacion.getWorld());
+            } else {
+                destruir();
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- load existing Nexos from `plugins/NexoAndCorruption/nexos` directory before falling back to default config
- trigger flash and explosion when a Nexo reaches zero health
- remove nexo from manager and delete its save file on destruction

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854da1091108330a8ad6ea6c5a26783