### PR TITLE
Eliminar nexo al morir el warden

### DIFF
--- a/src/main/java/nexo/beta/listeners/PlayerListener.java
+++ b/src/main/java/nexo/beta/listeners/PlayerListener.java
@@ -88,6 +88,7 @@ public class PlayerListener implements Listener {
 
         if (!warden.getUniqueId().equals(nexo.getWarden().getUniqueId())) return;
 
-        // No eliminar el Nexo al morir su Warden
+        nexo.setVida(0);
+        manager.eliminarNexo(warden.getWorld());
     }
 }


### PR DESCRIPTION
## Summary
- al morir el warden se elimina el nexo del mundo correspondiente

## Testing
- `mvn test` *(fails: mvn not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6854dc1868e4833086d4b8acdcbaa9b7