### PR TITLE
Broadcast nexus death

### DIFF
--- a/src/main/java/nexo/beta/classes/Nexo.java
+++ b/src/main/java/nexo/beta/classes/Nexo.java
@@ -420,6 +420,26 @@ public class Nexo {
     }
 
     /**
+     * Envía un mensaje global y reproduce un sonido cuando el Nexo muere.
+     */
+    private void enviarMensajeMuerte() {
+        String mensaje = configManager.getPrefijo() + configManager.getMensajeNexoInactivo();
+        if (configManager.isBroadcastNexoInactivo()) {
+            Bukkit.broadcastMessage(mensaje);
+        } else if (ubicacion.getWorld() != null) {
+            for (Player player : ubicacion.getWorld().getPlayers()) {
+                player.sendMessage(mensaje);
+            }
+        }
+
+        if (configManager.isSonidosHabilitados()) {
+            for (Player player : Bukkit.getOnlinePlayers()) {
+                player.playSound(player.getLocation(), configManager.getSonidoMuerte(), 1.0f, 1.0f);
+            }
+        }
+    }
+
+    /**
      * Verifica si hay jugadores cerca del Nexo
      */
     public boolean hayJugadoresCerca(int radio, int minimoJugadores) {
@@ -610,6 +630,7 @@ public class Nexo {
         // Si la vida llega a 0, eliminar el Nexo por completo
         if (this.vida <= 0 && activo) {
             mostrarDestruccion();
+            enviarMensajeMuerte();
             nexo.beta.managers.NexoManager manager = nexo.beta.managers.NexoManager.getInstance();
             if (manager != null) {
                 manager.eliminarNexo(ubicacion.getWorld());

--- a/src/main/java/nexo/beta/managers/ConfigManager.java
+++ b/src/main/java/nexo/beta/managers/ConfigManager.java
@@ -280,6 +280,15 @@ public class ConfigManager {
         }
     }
 
+    public Sound getSonidoMuerte() {
+        String soundName = nexoConfig.getString("nexo.efectos.sonidos.muerte", "ENTITY_WITHER_DEATH");
+        try {
+            return Sound.valueOf(soundName);
+        } catch (IllegalArgumentException e) {
+            return Sound.ENTITY_WITHER_DEATH;
+        }
+    }
+
     // ==========================================
     // MÉTODOS PARA ESTADOS CRÍTICOS
     // ==========================================
@@ -313,6 +322,10 @@ public class ConfigManager {
     public String getMensajeNexoInactivo() {
         return nexoConfig.getString("nexo.estados_criticos.nexo_inactivo.mensaje",
             "💀 ¡EL NEXO HA CAÍDO! Las protecciones han desaparecido.");
+    }
+
+    public boolean isBroadcastNexoInactivo() {
+        return nexoConfig.getBoolean("nexo.estados_criticos.nexo_inactivo.broadcast", true);
     }
 
     // ==========================================

--- a/src/main/resources/nexo.yml
+++ b/src/main/resources/nexo.yml
@@ -97,6 +97,7 @@ nexo:
       energia_baja: "BLOCK_NOTE_BLOCK_BASS"
       vida_baja: "ENTITY_VILLAGER_HURT"
       reinicio: "BLOCK_END_PORTAL_SPAWN"
+      muerte: "ENTITY_WITHER_DEATH"
 
   # Configuración de estados críticos
   estados_criticos:


### PR DESCRIPTION
## Summary
- broadcast a message and sound when a nexo dies
- expose new config options for death sound and broadcast toggle
- document new `muerte` sound in `nexo.yml`

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68558bf69bb88330a824a968d1f8c0e2