### PR TITLE
Add mob disintegration effect and open status command

### DIFF
--- a/src/main/java/nexo/beta/CommandManager/CommandNexoManager.java
+++ b/src/main/java/nexo/beta/CommandManager/CommandNexoManager.java
@@ -35,6 +35,11 @@ public class CommandNexoManager implements CommandExecutor {
         }
 
         String sub = args[0].toLowerCase();
+
+        if (!sub.equals("estado") && sender instanceof Player p && !p.hasPermission("nexo.admin")) {
+            sender.sendMessage(config.getMensajeSinPermisos());
+            return true;
+        }
         switch (sub) {
             case "crear":
                 if (!(sender instanceof Player player)) {

--- a/src/main/java/nexo/beta/Events/InvasionManager.java
+++ b/src/main/java/nexo/beta/Events/InvasionManager.java
@@ -7,6 +7,8 @@ import java.util.HashMap;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.World;
+import org.bukkit.Particle;
+import org.bukkit.Sound;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Monster;
@@ -155,6 +157,22 @@ public class InvasionManager {
             }
         }
         estadoPrevio.clear();
+
+        // Efecto de onda de choque al finalizar
+        for (Nexo nexo : nexoManager.getTodosLosNexos().values()) {
+            Location origin = nexo.getUbicacion();
+            if (origin.getWorld() == null) continue;
+            for (double r = 0; r < 2.5; r += 0.25) {
+                origin.getWorld().spawnParticle(
+                        Particle.CLOUD,
+                        origin.clone().add(0, 0.1, 0),
+                        20,
+                        r, 0.1, r,
+                        0.02
+                );
+            }
+            origin.getWorld().playSound(origin, Sound.ENTITY_GENERIC_EXPLODE, 0.8f, 1.0f);
+        }
     }
 
     public void detenerInvasion() {

--- a/src/main/java/nexo/beta/classes/Nexo.java
+++ b/src/main/java/nexo/beta/classes/Nexo.java
@@ -38,6 +38,7 @@ public class Nexo {
     private final Logger logger;
     private final String barrierId;
     private static final String WARDEN_TAG = "nexo_warden";
+    private static final String DISINTEGRATING_TAG = "nexo_disintegrating";
 
     // Estados del Nexo
     private int vida;
@@ -53,6 +54,7 @@ public class Nexo {
     private BukkitTask taskParticulas;
     private BukkitTask taskEfectos;
     private BukkitTask taskEliminarMobs;
+    private int stepRunas = 0;
 
     // Representación física del Nexo
     private Warden warden;
@@ -284,6 +286,13 @@ public class Nexo {
                 Location particleLocation = new Location(ubicacion.getWorld(), x, y, z);
                 ubicacion.getWorld().spawnParticle(particula, particleLocation, 1, 0, 0, 0, 0);
             }
+
+            for (int i = 0; i < 36; i++) {
+                double angle = Math.toRadians(i * 10 + (stepRunas * 5));
+                Location p = ubicacion.clone().add(Math.cos(angle) * 1.2, 0.05, Math.sin(angle) * 1.2);
+                ubicacion.getWorld().spawnParticle(Particle.ENCHANTMENT_TABLE, p, 1, 0, 0, 0, 0);
+            }
+            stepRunas++;
 
             // Partículas adicionales si está en estado crítico
             if (enEstadoCritico) {
@@ -729,7 +738,10 @@ public class Nexo {
                         }
                         String name = m.getCustomName();
                         if (name == null || name.isBlank()) {
-                            m.remove();
+                            if (!m.getScoreboardTags().contains(DISINTEGRATING_TAG)) {
+                                m.addScoreboardTag(DISINTEGRATING_TAG);
+                                nexo.beta.utils.DisintegrationUtil.disintegrate(m);
+                            }
                         }
                     }
                 }

--- a/src/main/java/nexo/beta/listeners/PlayerListener.java
+++ b/src/main/java/nexo/beta/listeners/PlayerListener.java
@@ -40,7 +40,7 @@ public class PlayerListener implements Listener {
             case DIAMOND, EMERALD -> {
                 player.getInventory().getItemInMainHand().setAmount(
                     player.getInventory().getItemInMainHand().getAmount() - 1);
-                nexo.alimentar(50);
+                nexo.alimentar(5);
                 player.sendMessage("§aHas alimentado el Nexo.");
             }
             case AMETHYST_SHARD -> {

--- a/src/main/java/nexo/beta/utils/DisintegrationUtil.java
+++ b/src/main/java/nexo/beta/utils/DisintegrationUtil.java
@@ -1,0 +1,58 @@
+package nexo.beta.utils;
+
+import org.bukkit.Location;
+import org.bukkit.Particle;
+import org.bukkit.Sound;
+import org.bukkit.entity.Entity;
+import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.scheduler.BukkitRunnable;
+
+import nexo.beta.NexoAndCorruption;
+
+public class DisintegrationUtil {
+
+    /**
+     * Aplica un efecto de desintegración al entity: anillos de partículas,
+     * humo, sonido de explosión final y remoción.
+     */
+    public static void disintegrate(Entity entity) {
+        Location origin = entity.getLocation();
+
+        new BukkitRunnable() {
+            int step = 0;
+            @Override
+            public void run() {
+                // Si el mob ya está muerto o pasó el número de pasos, remuévelo con explosión final
+                if (step > 12 || entity.isDead()) {
+                    origin.getWorld().spawnParticle(Particle.EXPLOSION_HUGE, origin, 1);
+                    origin.getWorld().playSound(origin, Sound.ENTITY_GENERIC_EXPLODE, 1f, 0.6f);
+                    entity.remove();
+                    cancel();
+                    return;
+                }
+
+                // Radio crece cada tick para simular expansión
+                double radius = 0.1 + step * 0.15;
+
+                // Genera un anillo de partículas CRIT_MAGIC y SMOKE_NORMAL
+                for (int i = 0; i < 24; i++) {
+                    double angle = 2 * Math.PI * i / 24;
+                    double dx = Math.cos(angle) * radius;
+                    double dz = Math.sin(angle) * radius;
+                    Location p = origin.clone().add(dx, 0.5, dz);
+
+                    origin.getWorld().spawnParticle(Particle.CRIT_MAGIC, p, 1, 0, 0, 0, 0);
+                    origin.getWorld().spawnParticle(Particle.SMOKE_NORMAL, p, 1, 0, 0, 0, 0);
+                }
+
+                // Sonido sutil de chispea a mitad de animación
+                if (step == 4 || step == 8) {
+                    origin.getWorld().playSound(origin, Sound.BLOCK_FIRE_EXTINGUISH, 0.5f, 1.2f);
+                }
+
+                step++;
+            }
+        // Ajusta NexoAndCorruption.class a la clase principal de tu plugin
+        }.runTaskTimer(JavaPlugin.getPlugin(NexoAndCorruption.class), 0L, 2L);
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -8,4 +8,3 @@ commands:
   nexo:
     description: "Gestiona el Nexo protector"
     usage: "/<command> <crear|destruir|estado|activar|desactivar|recargar|expandir>"
-    permission: "nexo.admin"


### PR DESCRIPTION
## Summary
- implement new `DisintegrationUtil` for flashy mob removal
- spawn rotating runes in particle effect around the Nexo
- disintegrate hostile mobs that enter the barrier
- add shockwave explosion when an invasion ends
- reduce diamond/emarald energy feed to 5
- allow `/nexo estado` for all players while guarding other subcommands
- remove global permission from `plugin.yml`

## Testing
- `mvn -q -DskipTests=false test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855907a98cc83308d1dceb4bd668c97