### PR TITLE
Implement skeleton corruption system

### DIFF
--- a/src/main/java/nexo/beta/managers/ConfigManager.java
+++ b/src/main/java/nexo/beta/managers/ConfigManager.java
@@ -441,6 +441,22 @@ public class ConfigManager {
     }
 
     // ==========================================
+    // MÉTODOS PARA LA CORRUPCIÓN
+    // ==========================================
+
+    public boolean isCorruptionEnabled() {
+        return nexoConfig.getBoolean("corruption.habilitado", true);
+    }
+
+    public int getCorruptionSpreadInterval() {
+        return nexoConfig.getInt("corruption.intervalo_expansion", 200);
+    }
+
+    public int getCorruptionBlocksPerCycle() {
+        return nexoConfig.getInt("corruption.bloques_por_ciclo", 5);
+    }
+
+    // ==========================================
     // MÉTODOS AUXILIARES
     // ==========================================
 

--- a/src/main/java/nexo/beta/managers/CorruptionManager.java
+++ b/src/main/java/nexo/beta/managers/CorruptionManager.java
@@ -1,0 +1,89 @@
+package nexo.beta.managers;
+
+import java.util.Random;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Chunk;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.World;
+import org.bukkit.block.Block;
+import org.bukkit.scheduler.BukkitRunnable;
+import org.bukkit.scheduler.BukkitTask;
+
+import nexo.beta.NexoAndCorruption;
+
+/**
+ * Gestiona la expansión básica de la corrupción en el mundo.
+ */
+public class CorruptionManager {
+
+    private final NexoAndCorruption plugin;
+    private final NexoManager nexoManager;
+    private ConfigManager config;
+
+    private BukkitTask task;
+    private final Random random = new Random();
+
+    public CorruptionManager(NexoAndCorruption plugin, NexoManager nexoManager, ConfigManager config) {
+        this.plugin = plugin;
+        this.nexoManager = nexoManager;
+        this.config = config;
+    }
+
+    public void start() {
+        if (task != null) {
+            task.cancel();
+        }
+        if (!config.isCorruptionEnabled()) return;
+
+        long interval = config.getCorruptionSpreadInterval();
+        task = new BukkitRunnable() {
+            @Override
+            public void run() {
+                ejecutarCiclo();
+            }
+        }.runTaskTimer(plugin, interval, interval);
+    }
+
+    public void shutdown() {
+        if (task != null) {
+            task.cancel();
+        }
+    }
+
+    public void reload(ConfigManager newConfig) {
+        this.config = newConfig;
+        start();
+    }
+
+    private void ejecutarCiclo() {
+        int bloques = config.getCorruptionBlocksPerCycle();
+        for (int i = 0; i < bloques; i++) {
+            World world = elegirMundo();
+            if (world == null) return;
+            Chunk[] loaded = world.getLoadedChunks();
+            if (loaded.length == 0) continue;
+            Chunk chunk = loaded[random.nextInt(loaded.length)];
+            int x = random.nextInt(16);
+            int z = random.nextInt(16);
+            int y = random.nextInt(world.getMaxHeight() - world.getMinHeight()) + world.getMinHeight();
+            Block block = chunk.getBlock(x, y, z);
+
+            Location loc = block.getLocation();
+            if (nexoManager.estaEnZonaProtegida(loc)) continue;
+
+            if (block.getType() == Material.DIRT || block.getType() == Material.GRASS_BLOCK) {
+                block.setType(Material.NETHERRACK);
+                if (config.isDebugHabilitado()) {
+                    plugin.getLogger().info("[DEBUG] Bloque corrompido en " + loc.toVector());
+                }
+            }
+        }
+    }
+
+    private World elegirMundo() {
+        if (Bukkit.getWorlds().isEmpty()) return null;
+        return Bukkit.getWorlds().get(random.nextInt(Bukkit.getWorlds().size()));
+    }
+}

--- a/src/main/java/nexo/beta/managers/PluginManager.java
+++ b/src/main/java/nexo/beta/managers/PluginManager.java
@@ -7,6 +7,7 @@ public class PluginManager {
     private ConfigManager configManager;
     private NexoManager nexoManager;
     private nexo.beta.Events.InvasionManager invasionManager;
+    private CorruptionManager corruptionManager;
     private NexoAndCorruption plugin;
 
     public static PluginManager getInstance() {
@@ -30,6 +31,7 @@ public class PluginManager {
             initializeNexoManager();
 
             initializeInvasionManager();
+            initializeCorruptionManager();
 
             plugin.getLogger().info("§a✅ Todos los managers inicializados correctamente");
 
@@ -63,6 +65,12 @@ public class PluginManager {
         plugin.getLogger().info("§a✅ InvasionManager inicializado");
     }
 
+    private void initializeCorruptionManager() {
+        corruptionManager = new CorruptionManager(plugin, nexoManager, configManager);
+        corruptionManager.start();
+        plugin.getLogger().info("§a✅ CorruptionManager inicializado");
+    }
+
     /**
      * Detiene todos los managers
      */
@@ -76,6 +84,10 @@ public class PluginManager {
 
         if (invasionManager != null) {
             invasionManager.shutdown();
+        }
+
+        if (corruptionManager != null) {
+            corruptionManager.shutdown();
         }
 
         plugin.getLogger().info("§a✅ Todos los managers detenidos correctamente");
@@ -102,6 +114,10 @@ public class PluginManager {
                 invasionManager.reload(configManager);
             }
 
+            if (corruptionManager != null) {
+                corruptionManager.reload(configManager);
+            }
+
             plugin.getLogger().info("§a✅ Todos los managers recargados correctamente");
 
         } catch (Exception e) {
@@ -124,6 +140,10 @@ public class PluginManager {
 
     public nexo.beta.Events.InvasionManager getInvasionManager() {
         return invasionManager;
+    }
+
+    public CorruptionManager getCorruptionManager() {
+        return corruptionManager;
     }
 
     public NexoAndCorruption getPlugin() {

--- a/src/main/resources/nexo.yml
+++ b/src/main/resources/nexo.yml
@@ -179,3 +179,10 @@ debug:
   mostrar_coordenadas: true
   mostrar_calculos_energia: false
   mostrar_eventos: true
+# ==========================================
+# CONFIGURACIÓN DE LA CORRUPCIÓN
+# ==========================================
+corruption:
+  habilitado: true
+  intervalo_expansion: 200    # ticks entre ciclos de expansión
+  bloques_por_ciclo: 5        # bloques a corromper por ciclo


### PR DESCRIPTION
## Summary
- add simple corruption manager that spreads netherrack on loaded chunks
- wire new manager into plugin startup/shutdown/reload
- expose corruption settings in config

## Testing
- `mvn -q -DskipTests package` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855a0f5f4b48330acb1df91fbfa754c