### PR TITLE
Fix missing corruption.yml in plugin jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,7 @@
                     <include>plugin.yml</include>
                     <include>config.yml</include>
                     <include>nexo.yml</include>
+                    <include>corruption.yml</include>
                 </includes>
             </resource>
         </resources>


### PR DESCRIPTION
## Summary
- include `corruption.yml` as part of the built resources

## Testing
- `mvn -q package` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855d24696a08330824db2140c8eb957