### PR TITLE
Fix missing corruption.yml in plugin jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,7 @@
                     <include>plugin.yml</include>
                     <include>config.yml</include>
                     <include>nexo.yml</include>
+                    <include>corruption.yml</include>
                 </includes>
             </resource>
         </resources>

--- a/src/main/java/nexo/beta/managers/ConfigManager.java
+++ b/src/main/java/nexo/beta/managers/ConfigManager.java
@@ -469,11 +469,11 @@ public class ConfigManager {
     }
 
     public int getCorruptionAreaMin() {
-        return corruptionConfig.getInt("corruption.area_min", 20);
+        return corruptionConfig.getInt("corruption.area_min", 100);
     }
 
     public int getCorruptionAreaMax() {
-        return corruptionConfig.getInt("corruption.area_max", 50);
+        return corruptionConfig.getInt("corruption.area_max", 200);
     }
 
     public List<Material> getCorruptionBlocks() {

--- a/src/main/resources/corruption.yml
+++ b/src/main/resources/corruption.yml
@@ -7,8 +7,8 @@ corruption:
   # Configuración básica
   intervalo_expansion: 200        # ticks entre ciclos de crecimiento
   bloques_por_ciclo: 5           # operaciones por ciclo
-  area_min: 30                   # tamaño mínimo de zona
-  area_max: 80                   # tamaño máximo de zona
+  area_min: 100                  # tamaño mínimo de zona
+  area_max: 200                  # tamaño máximo de zona
   
   # Configuración de crecimiento orgánico
   crecimiento_organico:


### PR DESCRIPTION
## Summary
- include `corruption.yml` as part of the built resources
- raise corruption area range to 100-200

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855d24696a08330824db2140c8eb957