### PR TITLE
Fix invasion logic when no nexus

### DIFF
--- a/src/main/java/nexo/beta/Events/InvasionManager.java
+++ b/src/main/java/nexo/beta/Events/InvasionManager.java
@@ -76,6 +76,14 @@ public class InvasionManager {
     }
 
     private void verificarCondiciones() {
+        // Si no existen Nexos activos, detener cualquier invasión y no iniciar
+        if (nexoManager.getNexosActivos() == 0) {
+            if (invasionEnCurso) {
+                detenerInvasion();
+            }
+            return;
+        }
+
         if (!invasionEnCurso) {
             double prob = config.getInvasionProbabilidad();
             if (Math.random() <= prob) {
@@ -182,6 +190,11 @@ public class InvasionManager {
     }
 
     private void generarEntidades() {
+        if (nexoManager.getNexosActivos() == 0) {
+            detenerInvasion();
+            return;
+        }
+
         Map<String, Double> mobs = config.getInvasionMobs();
         if (mobs.isEmpty()) return;
         Random rnd = new Random();


### PR DESCRIPTION
## Summary
- ensure invasion stops when no nexuses remain
- stop invasion entity generation if no active nexus exists

## Testing
- `mvn -q -e -DskipTests package` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859db1b32c08330b242b9fc2834386d