### PR TITLE
Improve nexus configuration defaults

### DIFF
--- a/src/main/java/nexo/beta/NexoAndCorruption.java
+++ b/src/main/java/nexo/beta/NexoAndCorruption.java
@@ -93,7 +93,8 @@ public class NexoAndCorruption extends JavaPlugin {
         getLogger().info("§e[DEBUG] ==========================================");
         getLogger().info("§e[DEBUG] Vida máxima: " + config.getVidaMaxima());
         getLogger().info("§e[DEBUG] Energía máxima: " + config.getEnergiaMaxima());
-        getLogger().info("§e[DEBUG] Consumo de energía/min: " + config.getConsumoEnergiaPorMinuto());
+        getLogger().info("§e[DEBUG] Consumo de energía/intervalo: " + config.getConsumoEnergiaBase());
+        getLogger().info("§e[DEBUG] Intervalo de consumo (min): " + config.getIntervaloConsumoEnergia());
         getLogger().info("§e[DEBUG] Radio de protección: " + config.getRadioProteccion());
         getLogger().info("§e[DEBUG] Ubicación del Nexo: " + config.getUbicacionNexo().toString());
         getLogger().info("§e[DEBUG] Nexos activos: " + nexo.getNexosActivos() + "/" + nexo.getTotalNexos());

--- a/src/main/java/nexo/beta/classes/Nexo.java
+++ b/src/main/java/nexo/beta/classes/Nexo.java
@@ -753,6 +753,11 @@ public class Nexo {
         actualizarBarrera();
     }
 
+    public void reducirRadio(int cantidad) {
+        this.radioActual = Math.max(radioBase, radioActual - cantidad);
+        actualizarBarrera();
+    }
+
     public void resetRadio() {
         this.radioActual = radioBase;
         actualizarBarrera();

--- a/src/main/java/nexo/beta/listeners/PlayerListener.java
+++ b/src/main/java/nexo/beta/listeners/PlayerListener.java
@@ -52,8 +52,8 @@ public class PlayerListener implements Listener {
             case REDSTONE -> {
                 player.getInventory().getItemInMainHand().setAmount(
                     player.getInventory().getItemInMainHand().getAmount() - 1);
-                nexo.resetRadio();
-                player.sendMessage("§cRadio del Nexo restablecido.");
+                nexo.reducirRadio(10);
+                player.sendMessage("§cRadio del Nexo reducido.");
             }
             default -> {
             }

--- a/src/main/java/nexo/beta/managers/ConfigManager.java
+++ b/src/main/java/nexo/beta/managers/ConfigManager.java
@@ -70,12 +70,16 @@ public class ConfigManager {
         return nexoConfig.getInt("nexo.energia_maxima", 1000);
     }
 
-    public int getConsumoEnergiaPorMinuto() {
-        return nexoConfig.getInt("nexo.energia_consumo_por_minuto", 10);
+    public int getConsumoEnergiaBase() {
+        return nexoConfig.getInt("nexo.energia_consumo_base", 17);
+    }
+
+    public int getIntervaloConsumoEnergia() {
+        return nexoConfig.getInt("nexo.energia_consumo_intervalo", 10);
     }
 
     public int getRadioProteccion() {
-        return nexoConfig.getInt("nexo.radio_proteccion", 50);
+        return nexoConfig.getInt("nexo.radio_proteccion", 500);
     }
 
     // ==========================================

--- a/src/main/java/nexo/beta/managers/NexoManager.java
+++ b/src/main/java/nexo/beta/managers/NexoManager.java
@@ -139,13 +139,15 @@ public class NexoManager {
             }.runTaskTimer(plugin, 20L, 20L); // Cada segundo (20 ticks)
         }
 
-        // Task de consumo de energía (cada minuto)
+        // Task de consumo de energía (intervalo configurable)
         taskConsumoEnergia = new BukkitRunnable() {
             @Override
             public void run() {
                 consumirEnergiaTodosLosNexos();
             }
-        }.runTaskTimer(plugin, 1200L, 1200L); // Cada minuto (1200 ticks)
+        }.runTaskTimer(plugin,
+                       configManager.getIntervaloConsumoEnergia() * 1200L,
+                       configManager.getIntervaloConsumoEnergia() * 1200L);
 
         // Task de guardado automático
         if (configManager.getIntervaloGuardadoAuto() > 0) {
@@ -295,7 +297,7 @@ public class NexoManager {
      * Consume energía de todos los Nexos activos
      */
     private void consumirEnergiaTodosLosNexos() {
-        int consumoBase = configManager.getConsumoEnergiaPorMinuto();
+        int consumoBase = configManager.getConsumoEnergiaBase();
 
         for (Nexo nexo : nexosPorMundo.values()) {
             if (nexo.estaActivo()) {

--- a/src/main/resources/nexo.yml
+++ b/src/main/resources/nexo.yml
@@ -6,10 +6,13 @@ nexo:
   # Configuración básica del Nexo
   vida_maxima: 1000
   energia_maxima: 1000
-  energia_consumo_por_minuto: 10
+  # Energía consumida cada intervalo
+  energia_consumo_base: 17
+  # Intervalo de consumo en minutos
+  energia_consumo_intervalo: 10
 
   # Radio de protección (en bloques)
-  radio_proteccion: 50
+  radio_proteccion: 500
 
   # Configuración de ubicación
   ubicacion:


### PR DESCRIPTION
## Summary
- raise default protection radius to 500
- add configurable energy consumption interval
- slow down base energy consumption
- allow reducing nexus radius with redstone

## Testing
- `mvn -q -DskipTests package` *(fails: mvn not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6859def0795c83309fa01001f7d2e4da