### PR TITLE
Prevent early invasion end when nexo inactive

### DIFF
--- a/src/main/java/nexo/beta/Events/InvasionManager.java
+++ b/src/main/java/nexo/beta/Events/InvasionManager.java
@@ -76,9 +76,11 @@ public class InvasionManager {
     }
 
     private void verificarCondiciones() {
-        // Si no existen Nexos activos, detener cualquier invasión y no iniciar
+        // Si no existen Nexos activos, detener cualquier cuenta regresiva
+        // pero permitir que una invasión ya activa continúe.
         if (nexoManager.getNexosActivos() == 0) {
-            if (invasionEnCurso) {
+            // Solo cancelar si la invasión aún no ha comenzado
+            if (invasionEnCurso && !invasionActiva) {
                 detenerInvasion();
             }
             return;


### PR DESCRIPTION
## Summary
- keep invasion going even when all nexos are temporarily inactive

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859e342d01483308c2cfd9184e7f222