### PR TITLE
Update Nexo defaults and invasion checks

### DIFF
--- a/src/main/java/nexo/beta/Events/InvasionManager.java
+++ b/src/main/java/nexo/beta/Events/InvasionManager.java
@@ -77,6 +77,9 @@ public class InvasionManager {
 
     private void verificarCondiciones() {
         if (!invasionEnCurso) {
+            if (nexoManager.getNexosActivos() <= 0) {
+                return;
+            }
             double prob = config.getInvasionProbabilidad();
             if (Math.random() <= prob) {
                 iniciarCuentaRegresiva();

--- a/src/main/java/nexo/beta/classes/Nexo.java
+++ b/src/main/java/nexo/beta/classes/Nexo.java
@@ -211,9 +211,10 @@ public class Nexo {
         warden.addScoreboardTag(WARDEN_TAG);
         warden.getAttribute(Attribute.MAX_HEALTH).setBaseValue(configManager.getVidaMaxima());
         warden.setHealth(Math.min(vida, configManager.getVidaMaxima()));
+        warden.setInvisible(configManager.isWardenInvisible());
 
         texturaStand = (ArmorStand) ubicacion.getWorld().spawnEntity(ubicacion, EntityType.ARMOR_STAND);
-        texturaStand.setInvisible(true);
+        texturaStand.setInvisible(configManager.isArmorStandInvisible());
         texturaStand.setMarker(true);
         texturaStand.setGravity(false);
         ItemStack flint = new ItemStack(Material.FLINT);

--- a/src/main/java/nexo/beta/managers/ConfigManager.java
+++ b/src/main/java/nexo/beta/managers/ConfigManager.java
@@ -78,6 +78,14 @@ public class ConfigManager {
         return nexoConfig.getInt("nexo.radio_proteccion", 50);
     }
 
+    public boolean isWardenInvisible() {
+        return nexoConfig.getBoolean("nexo.representacion.warden_invisible", true);
+    }
+
+    public boolean isArmorStandInvisible() {
+        return nexoConfig.getBoolean("nexo.representacion.armorstand_invisible", false);
+    }
+
     // ==========================================
     // MÉTODOS PARA UBICACIÓN DEL NEXO
     // ==========================================

--- a/src/main/resources/nexo.yml
+++ b/src/main/resources/nexo.yml
@@ -5,11 +5,16 @@
 nexo:
   # Configuración básica del Nexo
   vida_maxima: 1000
-  energia_maxima: 1000
-  energia_consumo_por_minuto: 10
+  energia_maxima: 1200
+  energia_consumo_por_minuto: 2
 
   # Radio de protección (en bloques)
-  radio_proteccion: 50
+  radio_proteccion: 500
+
+  # Apariencia de la representación
+  representacion:
+    warden_invisible: true
+    armorstand_invisible: false
 
   # Configuración de ubicación
   ubicacion:


### PR DESCRIPTION
## Summary
- set default radius to 500 blocks and adjust energy settings
- add configuration options to hide the warden or armor stand
- make warden invisible and armor stand visibility configurable
- only allow invasions when a nexo is active

## Testing
- `mvn -q -DskipTests package` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859e9ee188c833097968937a222edeb