### PR TITLE
Improve invasion countdown notices

### DIFF
--- a/src/main/java/nexo/beta/Events/InvasionManager.java
+++ b/src/main/java/nexo/beta/Events/InvasionManager.java
@@ -99,7 +99,22 @@ public class InvasionManager {
                     cancel();
                     return;
                 }
-                if (tiempo % 10 == 0 || tiempo <= 5) {
+
+                if (tiempo > 3600) {
+                    if (tiempo % 3600 == 0) {
+                        int horas = tiempo / 3600;
+                        Bukkit.broadcastMessage(Utils.colorize(config.getPrefijo() + "§cInvasión en " + horas + "h"));
+                    }
+                } else if (tiempo > 60) {
+                    if (tiempo % 60 == 0) {
+                        int minutos = tiempo / 60;
+                        Bukkit.broadcastMessage(Utils.colorize(config.getPrefijo() + "§cInvasión en " + minutos + "m"));
+                    }
+                } else if (tiempo > 10) {
+                    if (tiempo % 10 == 0) {
+                        Bukkit.broadcastMessage(Utils.colorize(config.getPrefijo() + "§cInvasión en " + tiempo + "s"));
+                    }
+                } else {
                     Bukkit.broadcastMessage(Utils.colorize(config.getPrefijo() + "§cInvasión en " + tiempo + "s"));
                 }
                 tiempo--;

--- a/src/main/java/nexo/beta/classes/Nexo.java
+++ b/src/main/java/nexo/beta/classes/Nexo.java
@@ -694,6 +694,13 @@ public class Nexo {
         return warden;
     }
 
+    /**
+     * Obtiene el ArmorStand que representa visualmente al Nexo.
+     */
+    public ArmorStand getTexturaStand() {
+        return texturaStand;
+    }
+
     public ConfigManager getConfigManager() {
         return configManager;
     }

--- a/src/main/java/nexo/beta/listeners/PlayerListener.java
+++ b/src/main/java/nexo/beta/listeners/PlayerListener.java
@@ -66,15 +66,27 @@ public class PlayerListener implements Listener {
 
     @EventHandler(priority = EventPriority.HIGHEST)
     public void onPlayerDamageNexo(EntityDamageByEntityEvent event) {
-        if (!(event.getEntity() instanceof Warden warden)) return;
+        org.bukkit.entity.Entity entity = event.getEntity();
 
         NexoManager manager = NexoAndCorruption.getNexoManagerStatic();
         if (manager == null) return;
 
-        Nexo nexo = manager.getNexoEnMundo(warden.getWorld());
+        Nexo nexo = manager.getNexoEnMundo(entity.getWorld());
         if (nexo == null || nexo.getWarden() == null) return;
 
-        if (!warden.getUniqueId().equals(nexo.getWarden().getUniqueId())) return;
+        boolean objetivo = false;
+        if (entity instanceof Warden warden) {
+            if (warden.getUniqueId().equals(nexo.getWarden().getUniqueId())) {
+                objetivo = true;
+            }
+        } else if (entity instanceof org.bukkit.entity.ArmorStand stand) {
+            if (nexo.getTexturaStand() != null
+                    && stand.getUniqueId().equals(nexo.getTexturaStand().getUniqueId())) {
+                objetivo = true;
+            }
+        }
+
+        if (!objetivo) return;
 
         Player damager = null;
         if (event.getDamager() instanceof Player p) {


### PR DESCRIPTION
## Summary
- add adaptive countdown messages so invasion warnings appear hourly, then minutely, then per second as the start approaches
- block player attacks on the Nexo and its visual representation

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a03b8246c8330847d5eb3ff6eed25