### PR TITLE
Fix warden damage processing order

### DIFF
--- a/src/main/java/nexo/beta/listeners/PlayerListener.java
+++ b/src/main/java/nexo/beta/listeners/PlayerListener.java
@@ -108,7 +108,7 @@ public class PlayerListener implements Listener {
         }
     }
 
-    @EventHandler(ignoreCancelled = true)
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onEntityDamage(EntityDamageEvent event) {
         if (!(event.getEntity() instanceof Warden warden)) return;
 


### PR DESCRIPTION
## Summary
- ensure warden damage only reduces Nexus health after cancellation is processed

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a07de8560833083c5f39c0e7fd9ce